### PR TITLE
Add ability to change default lat/lon/z

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,50 @@
       A rendering of the current state of the project is reflected
       at our <a href="http://ohmec.net">Website</a>.
     </p>
+    <p>
+      Arguments can be passed to the URL to modify timeline parameters
+      and default viewing perspective. These arguments are shown below,
+      and are set as for example
+      <font face="Courier">http://ohmec.net?parameter=value&amp;parameter=value</font>.
+    </p>
+    <table id="paramtable">
+      <tr>
+        <th>parameter</th>
+        <th>argument</th>
+        <th>description</th>
+      </tr>
+      <tr>
+        <td>startdatestr</td>
+        <td>YYYY:MM:DD</td>
+        <td>Sets timeline slider start date to MM/DD/YYYY</td>
+      </tr>
+      <tr>
+        <td>enddatestr</td>
+        <td>YYYY:MM:DD</td>
+        <td>Sets timeline slider end date to MM/DD/YYYY</td>
+      </tr>
+      <tr>
+        <td>curdatestr</td>
+        <td>YYYY:MM:DD</td>
+        <td>Sets timeline slider current date to MM/DD/YYYY</td>
+      </tr>
+      <tr>
+        <td>lat</td>
+        <td>N</td>
+        <td>Sets center latitude to value N (range -90 to 90)</td>
+      </tr>
+      <tr>
+        <td>lon</td>
+        <td>N</td>
+        <td>Sets center longitude to value N (range -180 to 180)</td>
+      </tr>
+      <tr>
+        <td>z</td>
+        <td>N</td>
+        <td>Sets zoom value to N (range 1 to 18)</td>
+      </tr>
+    </table>
+
     <script type="text/javascript" src="ohmec_data_na.js"></script>
     <script type="text/javascript" src="time_slider.js"></script>
     <script type="text/javascript" src="geo_features.js"></script>

--- a/ohmec.css
+++ b/ohmec.css
@@ -63,3 +63,10 @@ h1 {
 .infobox a:visited {
   color: #eee;
 }
+#paramtable {
+  font-family: "Courier";
+  font-size: 13px;
+  border:solid;
+  border-collapse: separate;
+  border-spacing: 15px 0px;
+}

--- a/ohmec.js
+++ b/ohmec.js
@@ -2,7 +2,55 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-let ohmap = L.map('map').setView([39, -110], 4);
+// check for URL override
+
+let parameters = location.search.substring(1).split("&");
+
+let today = new Date();
+let timelineMin = today;
+let timelineMax = new Date(1,0,1);
+let timelineStart = new Date(1850,11,13); // oldest date that has all the polygons entered for US region
+let overrideMin = 1;
+let overrideMax = 1;
+let latSetting = 39;
+let lonSetting = -110;
+let zoomSetting = 4;
+
+for(let param of parameters) {
+  let test = /(startdatestr|enddatestr|curdatestr)=(\d+:\d+:\d+)/;
+  let match = param.match(test);
+  if (match !== null) {
+    let info = match[2].split(':');
+    let dateVal = new Date(info[0],info[1]-1,info[2]);
+    if (match[1] == 'startdatestr') {
+      timelineMin = dateVal;
+      overrideMin = 0;
+    }
+    if (match[1] == 'enddatestr') {
+      timelineMax = dateVal;
+      overrideMax = 0;
+    }
+    if (match[1] == 'curdatestr') {
+      timelineStart = dateVal;
+    }
+  }
+  test = /(lat|lon|z)=(\-?\d+)/;
+  match = param.match(test);
+  if (match !== null) {
+    let info = match[2];
+    if (match[1] == 'lat' && info >= -90 && info <= 90) {
+      latSetting = info;
+    }
+    if (match[1] == 'lon' && info >= -180 && info <= 180) {
+      lonSetting = info;
+    }
+    if (match[1] == 'z' && info >= 1 && info <= 18) {
+      zoomSetting = info;
+    }
+  }
+}
+
+let ohmap = L.map('map').setView([latSetting, lonSetting], zoomSetting);
 
 L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={ohmec_mapbox_token}', {
   maxZoom: 18,
@@ -38,37 +86,7 @@ infobox.update = function(id, prop) {
 infobox.addTo(ohmap);
 
 let legend = L.control({position: 'bottomright'});
-let today = new Date();
-let curDate = new Date();
-let timelineMin = today;
-let timelineMax = new Date(1,0,1);
-let timelineStart = new Date(1850,11,13); // oldest date that has all the polygons entered for US region
-let overrideMin = 1;
-let overrideMax = 1;
-
-// check for URL override
-
-let parameters = location.search.substring(1).split("&");
-
-for(let param of parameters) {
-  let test = /(startdatestr|enddatestr|curdatestr)=(\d+:\d+:\d+)/;
-  let match = param.match(test);
-  if (match !== null) {
-    let info = match[2].split(':');
-    let dateVal = new Date(info[0],info[1]-1,info[2]);
-    if (match[1] == 'startdatestr') {
-      timelineMin = dateVal;
-      overrideMin = 0;
-    }
-    if (match[1] == 'enddatestr') {
-      timelineMax = dateVal;
-      overrideMax = 0;
-    }
-    if (match[1] == 'curdatestr') {
-      timelineStart = dateVal;
-    }
-  }
-}
+let curDate = today;
 
 function dateMin(minDate, newDate) {
   return (minDate < newDate) ? minDate : newDate;


### PR DESCRIPTION
Fixes #41 

Adds URL arguments ?lat= ?lon= and ?z= to override default latitude, longitude and/or zoom

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>