### PR TITLE
Fix #65 bug in zoom out button

### DIFF
--- a/ohmec.js
+++ b/ohmec.js
@@ -54,7 +54,7 @@ let ohmap = L.map('map', {
   center:        [latSetting, lonSetting],
   zoom:          zoomSetting,
   zoomSnap:      0.5,
-  zoomDelta:     0.25,
+  zoomDelta:     0.5,
   worldCopyJump: false  // true would replicate upon panning far west/east, but has unattractive skips
 });
 


### PR DESCRIPTION
Fixes #65 

For some reason you can't have a different value for zoomDelta than zoomSnap. When different either one or both of the +/- buttons will fail. Leaving with zoom delta of 0.5 for now.

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>