### PR TITLE
Adding pointers to newly created explanatory collateral.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,8 @@ The OHMEC project has a goal to create an open geographical database of historic
 It is in a nascent stage, using [leaflet](https://leafletjs.com) to visualize data stored in a JSON structure that is currently handcrafted.
 Contributions are welcome.
 
+See [this slidedeck](https://docs.google.com/presentation/d/1WiXMrLPC4fOwNaKD7UhH2Wb1JSVcva5z4sNdd0qS7vg/edit?usp=sharing) for more insight into the project.
+
+A specification of the [extended GeoJSON](https://docs.google.com/document/d/15D9t61Y1WYYH02BuIp3C8InJD40L19uHIcPNDfNv0Bk/edit?usp=sharing) format that underpins the historical database is provided here.
+
 An up to date rendering can be found in our [Github Mirror Page](http://ohmec.net).

--- a/index.html
+++ b/index.html
@@ -37,7 +37,11 @@
       The OHMEC project is being developed openly in a
       <a href="https://github.com/ohmec/ohmec" target="_blank">Github repository</a>.
       Participation is welcome, see that repo for more information
-      on the management of the project.
+      on the management of the project. Also see
+      <a href="https://docs.google.com/presentation/d/1WiXMrLPC4fOwNaKD7UhH2Wb1JSVcva5z4sNdd0qS7vg/edit?usp=sharing">this slidedeck</a>
+      for more insight into the project. A specification of the
+      <a href="https://docs.google.com/document/d/15D9t61Y1WYYH02BuIp3C8InJD40L19uHIcPNDfNv0Bk/edit?usp=sharing">extended GeoJSON</a>
+      format that underpins the historical database is provided here.
     </p>
     <p>
       Holding the shift key down and creating a bounding box will redefine


### PR DESCRIPTION
Fixes #6 

Newly created explanatory collateral is linked into the project README and into the main index.html page.

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>