### PR TITLE
Codify borderless property

### DIFF
--- a/geo_features.js
+++ b/geo_features.js
@@ -4,7 +4,7 @@
 
 function featureStyle(feature) {
   // default styles
-  let strokeOn      = true;
+  let strokeOn      = true;       // hides feature boundaries if false
   let strokeOpacity = 1.0;
   let strokeColor   = 'white';
   let strokeWeight  = 2.0;
@@ -19,8 +19,12 @@ function featureStyle(feature) {
   let entity1name = feature.properties.entity1name;
   let entity2type = feature.properties.entity2type;
   let entity2name = feature.properties.entity2name;
-  // declare a new feature 'borderless' that is false for most
-  feature.borderless = false;
+
+  // declare a new property 'borderless' if not already given
+  let borderless  = false;
+  if("borderless" in feature.properties) {
+    borderless = feature.properties.borderless;
+  }
 
   if(entity1name == 'England' && entity2type == 'grant') {
     strokeColor  = '#a00000';
@@ -38,9 +42,12 @@ function featureStyle(feature) {
     strokeDash   = '1';
     fillColor    = '#a06060';
   } else if(entity1name == 'Indigenous' && entity2type == 'tribe') {
-    strokeOn     = false;  // set to 'false' to hide territory 'boundary' rectangles; set to 'true' to visualize territory 'boundaries'
+    strokeOn     = false;
     fillOpacity  = 0.0;
-    feature.borderless = true;
+    // don't override a pre-defined property, but otherwise set to true for indigenous
+    if(!("borderless" in feature.properties)) {
+      borderless = true;
+    }
   } else if(entity1name == 'USA' && entity2type == 'secessionist') {
     strokeColor  = '#0000a0';
     strokeWeight = 2.0;
@@ -138,6 +145,10 @@ function featureStyle(feature) {
     fillColor    = '#031056';
   }
 
+  // since we're making borderless a largely hidden property, and
+  // using it later, set it indefinitely
+  feature.properties.borderless = borderless;
+
   // returning all style contents even if default, just to have as reference
   // (see https://leafletjs.com/reference-1.7.1.html#path-option)
   return {
@@ -163,19 +174,18 @@ function getFeatureLabel(feature) {
 function getFeatureFont(feature) {
   // default styles
   let fontchoice = 9;
-  let fontname = 'sans serif';
-  let fontscale = 1;
-  let fontcolor = "black";
+  let fontname   = 'sans serif';
+  let fontscale  = 1;
+  let fontcolor  = "black";
 
   // lookup table for entity types and names, mapping to font and font color and other info
   let entity1name = feature.properties.entity1name;
   let entity2type = feature.properties.entity2type;
-  let entity2name = feature.properties.entity2name;
 
   if(entity1name == 'Indigenous' && entity2type == 'tribe') {
-      fontchoice   = 3;
-      fontcolor    = "red";
-    };
+    fontchoice = 3;
+    fontcolor  = "red";
+  }
 
   // scale the font based upon the family, since some are wider than others
   switch(fontchoice) {

--- a/ohmec.js
+++ b/ohmec.js
@@ -32,7 +32,7 @@ for(let param of parameters) {
       timelineStart = str2date(match[2],false);
     }
   }
-  test = /(lat|lon|z)=(\-?[\d.]+)/;
+  test = /(lat|lon|z)=(-?[\d.]+)/;
   match = param.match(test);
   if (match !== null) {
     let info = match[2];
@@ -58,7 +58,7 @@ let ohmap = L.map('map', {
 
 let linkSpan = document.querySelector('#directlink');
 
-let updateDirectLink = function(ev) {
+let updateDirectLink = function() {
   let hrefText = location.href;
   let splits = hrefText.split('?');
   let latlon = ohmap.getCenter();
@@ -134,13 +134,14 @@ let geojson;
 function highlightFeature(e) {
   let layer = e.target;
 
-  if (layer.feature.geometry.type !== "Point") {  // default Point style being used at this time
-    let opacity = (layer.feature.borderless) ? 0.0 : 0.7;
+  if (layer.feature.geometry.type !== "Point") {  // Point styles are not being overridden at this time
+    // borderless features shouldn't be highlighted (but still have selectability)
+    let opacity = (layer.feature.properties.borderless) ? 0.0 : 0.7;
     layer.setStyle({
       weight: 5,
       color: '#666',
       dashArray: '',
-      fillOpacity: opacity // 0.7
+      fillOpacity: opacity
     });
 
     if (!L.Browser.ie && !L.Browser.opera && !L.Browser.edge) {
@@ -298,7 +299,6 @@ function geo_lint(dataset) {
           if(!(required in p))
             throw "feature " + f.id + " missing property " + required;
         }
-        let contents = p.startdatestr.split(':');
         p.startDate = str2date(p.startdatestr,false);
         if(p.enddatestr == 'present') {
           p.endDate = today;


### PR DESCRIPTION
Fixes #92 

Fixes #9 

The property `borderless` was added in #89, but this formalizes it as a feature property, allowing it to be set in the feature database (eg `ohmec_data_na.js`), or algorithmically (like it is now for Indigenous tribes).

The documentation has been updated as well.

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>