### PR TITLE
Implementing "smart step" buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,17 @@
       Feature Information for further inspection.
     </p>
     <p>
+      Keyboard inputs can modify the display behavior. At this time only
+      one key press modifies the result.  Pressing the <code><b>s</b></code>
+      toggles the "smart step" button feature. When enabled (default true),
+      the step + and step - buttons move the timeline slider forward or
+      backward to the next time where a change in the database is visible
+      in the current viewpoint. When false, the step buttons simply move
+      to the next or previous change in the database.  NOTE the user must
+      click on the map once to indicate focus on it (vs other browser items)
+      before any keyboard event.
+    </p>
+    <p>
       Arguments can be passed to the URL to modify timeline parameters
       and default viewing perspective. These arguments are shown below,
       and are set as for example
@@ -89,6 +100,11 @@
         <td>z</td>
         <td>N</td>
         <td>Sets zoom value to N (range 1 to 18)</td>
+      </tr>
+      <tr>
+        <td>smartstep</td>
+        <td>on|off</td>
+        <td>Enables or disables the smart step feature.</td>
       </tr>
     </table>
     <p>


### PR DESCRIPTION
Addresses #94 

This is still exploratory, but implements a selectable "smart step" button feature, whereby the current viewpoint bounds rectangle is compared against those features that would be added or removed by the step forward or backward. If the bounds intersect for any of the added or removed features, then the step is used, else it tries the next step. It isn't perfect since bounds can intersect while the actual features might not intersect, but otherwise it works pretty well.

If this were to be merged, it would come with a web-variable override option, but in this draft "smart step" is always true.

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>