### PR TITLE
Exploratory code for Step Changes info box

### DIFF
--- a/ohmec.css
+++ b/ohmec.css
@@ -23,7 +23,7 @@ h1 {
   align: center;
   border: solid;
 }
-.curdate, .infobox {
+.curdate, .infobox, .stepbox {
   padding: 6px 8px;
   font: 14px/16px Helvetica, sans-serif;
   background: white;


### PR DESCRIPTION
Addresses #93 

This is pretty ugly code, but just showing what the Step Info Box could look like to inform the user what changed in between each step. Not sure yet what I think about, but it works both with and without the "Smart Step" of PR #108. Might be extraneous if we go with Smart Step. Currently it is not implemented, but I'd prefer a URL option a la `&stepinfo=1` or something like that. Also, I'd prefer that it vanish if it doesn't have anything to say, but didn't add that yet. Just a draft for now.

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>