### PR TITLE
Allow toggling of layer selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,8 +45,9 @@
     </p>
     <p>
       Holding the shift key down and creating a bounding box will redefine
-      the current zoom window. Clicking on a polygon will hold the
-      Feature Information for further inspection.
+      the current zoom window. Clicking on a polygon will deprioritize
+      it in the "click stack" when there are multiple overlapping features,
+      allowing the user to hover over the lower ones to see their information.
     </p>
     <p>
       Visualization and control can be modified by key press events.
@@ -95,11 +96,18 @@
         </td>
       </tr>
       <tr>
+        <td>i</td>
+        <td>Toggles enable/disable of "pinning" the feature information
+            for the currently selected feature. Press once to pin, a
+            second time to unpin. Panning, zooming, or changing the date
+            also releases the pin.
+        </td>
+      </tr>
+      <tr>
         <td>r</td>
         <td>
           Resets the view to the default lat/lon/z settings, that is the default
           of the database, or as overriden by URL parameters.
-        </td>
       </tr>
       <tr>
         <td>s</td>
@@ -123,7 +131,7 @@
         </td>
       </tr>
       <tr>
-        <td>&gt; or .</td>
+        <td>&gt; .</td>
         <td>
           Step forward. Equivalent to pressing the (Step +) button on the page.
           The amount to step forward is under the management of the Smart Step
@@ -131,7 +139,7 @@
         </td>
       </tr>
       <tr>
-        <td>&lt; or ,</td>
+        <td>&lt; ,</td>
         <td>
           Step backward. Equivalent to pressing the (Step -) button on the page.
           The amount to step backward is under the management of the Smart Step

--- a/ohmec.css
+++ b/ohmec.css
@@ -67,7 +67,9 @@ h1 {
   font-family: "Courier";
   font-size: 13px;
   width: 750px;
-  border:solid;
+  border-style:solid;
+  border-width:2px;
+  border-color:black;
   border-collapse: separate;
   border-spacing: 15px 0px;
   background: #d8d8d8;

--- a/time_slider.js
+++ b/time_slider.js
@@ -101,6 +101,9 @@ L.Control.TimeLineSlider = L.Control.extend({
       }
       timelineSlider.rangeObject.value = newTime;
       timelineSlider.options.updateTime({dateValue: timelineSlider.rangeObject.value});
+      infobox._div.style.background = infoboxNormalBackground;
+      infoPinned = false;
+      infobox.update();
     }
 
     timelineSlider.affectAdvance = function() {
@@ -147,6 +150,9 @@ L.Control.TimeLineSlider = L.Control.extend({
               timelineSlider.rangeObject.value = datesOfInterestSorted[i].getTime();
               timelineSlider.options.updateTime({dateValue: timelineSlider.rangeObject.value});
             }
+            infobox._div.style.background = infoboxNormalBackground;
+            infoPinned = false;
+            infobox.update();
             return;
           }
         }
@@ -186,6 +192,9 @@ L.Control.TimeLineSlider = L.Control.extend({
               timelineSlider.rangeObject.value = datesOfInterestSorted[i].getTime();
               timelineSlider.options.updateTime({dateValue: timelineSlider.rangeObject.value});
             }
+            infobox._div.style.background = infoboxNormalBackground;
+            infoPinned = false;
+            infobox.update();
             return;
           }
         }


### PR DESCRIPTION
fixes #91 

This small fix pushes a selected layer "to the back", thereby allowing user's to toggle between overlapping layers. In my brief tests, double-stacked layers were selected alternately with each "info click", which should suffice. I will add this to the documentation.

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>