### PR TITLE
Add ability to change base layer map

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
       Feature Information for further inspection.
     </p>
     <p>
+<<<<<<< HEAD
       Keyboard inputs can modify the display behavior. At this time only
       one key press modifies the result.  Pressing the <code><b>s</b></code>
       toggles the "smart step" button feature. When enabled (default true),
@@ -59,6 +60,46 @@
       click on the map once to indicate focus on it (vs other browser items)
       before any keyboard event.
     </p>
+=======
+      Visualization and control can be modified by key press events.
+      The following keys pressed <b>after click-selecting the map
+      pane</b> have a particular effect.
+    </p>
+    <table id="keytable">
+      <tr>
+        <th>key</th>
+        <th>effect</th>
+      </tr>
+      <tr>
+        <td>0</td>
+        <td>Modify underlying base map to use unlabeled relief map (default)</td>
+      </tr>
+      <tr>
+        <td>1</td>
+        <td>Modify underlying base map to use unlabeled darker world imagery map</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>Modify underlying base map to use unlabeled light physical imagery map</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>Modify underlying base map to use unlabeled white relief map</td>
+      </tr>
+      <tr>
+        <td>4</td>
+        <td>Modify underlying base map to use unlabeled Stamen terrain map</td>
+      </tr>
+      <tr>
+        <td>5</td>
+        <td>Modify underlying base map to use labeled street map</td>
+      </tr>
+      <tr>
+        <td>6</td>
+        <td>Modify underlying base map to use unlabeled watercolor "paint" map</td>
+      </tr>
+    </table>
+>>>>>>> 98e8059 (Add ability to change base layer map)
     <p>
       Arguments can be passed to the URL to modify timeline parameters
       and default viewing perspective. These arguments are shown below,

--- a/ohmec.css
+++ b/ohmec.css
@@ -26,8 +26,6 @@ h1 {
 .curdate, .infobox {
   padding: 6px 8px;
   font: 14px/16px Helvetica, sans-serif;
-  background: white;
-  background: rgba(4,112,255,0.7);
   box-shadow: 0 0 15px rgba(0,0,0,0.2);
   border-radius: 5px;
   background-color: rgba(4,112,255,0.7);
@@ -65,7 +63,7 @@ h1 {
 .infobox a:visited {
   color: #eee;
 }
-#paramtable {
+#paramtable,#keytable {
   font-family: "Courier";
   font-size: 13px;
   border:solid;
@@ -75,4 +73,20 @@ h1 {
 #directlink {
   font-family: "Courier";
   font-size: 11px;
+}
+.leaflet-control-layers-toggle {
+  box-shadow: 0 0 15px rgba(0,0,0,0.2);
+  background-color: rgba(4,112,255,0.7);
+  border-style: solid;
+  border-color: #0470ff;
+  border-width: 1px;
+}
+.leaflet-control-layers {
+  font: 14px/16px Helvetica, sans-serif;
+  box-shadow: 0 0 15px rgba(0,0,0,0.2);
+  background-color: rgba(4,112,255,0.7);
+  border-style: solid;
+  border-color: #0470ff;
+  border-width: 1px;
+  color: #eee
 }


### PR DESCRIPTION
Fixes #125 

This gives us 6 base layer options, and changes the default to the most innocuous.

It also key maps `0` to `5` to toggle maps, or you can use the layer selector in the upper right corner.

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>