### PR TITLE
Clean up HTML front page, prepare for BC

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
         <td>s</td>
         <td>
           Toggles the "smart step" button feature. When enabled (default true),
-          the step + and step - buttons move the timeline slider forward or
+          the (Step +) and (Step -) buttons move the timeline slider forward or
           backward to the next time where a change in the database is visible
           in the current viewpoint. When false, the step buttons simply move
           to the next or previous change in the database.  NOTE the user must
@@ -114,37 +114,42 @@
       <tr>
         <td>startdatestr</td>
         <td>YYYY:MM:DD</td>
-        <td>Sets timeline slider start date to MM/DD/YYYY</td>
+        <td>Sets timeline slider start date to MM/DD/YYYY. Default is <span id='startdef'>zzz</span>.</td>
       </tr>
       <tr>
         <td>enddatestr</td>
         <td>YYYY:MM:DD</td>
-        <td>Sets timeline slider end date to MM/DD/YYYY</td>
+        <td>Sets timeline slider end date to MM/DD/YYYY. Default is <span id='enddef'>zzz</span>.</td>
       </tr>
       <tr>
         <td>curdatestr</td>
         <td>YYYY:MM:DD</td>
-        <td>Sets timeline slider current date to MM/DD/YYYY</td>
+        <td>Sets timeline slider current date to MM/DD/YYYY. Default is <span id='curdef'>zzz</span>.</td>
       </tr>
       <tr>
         <td>lat</td>
         <td>N</td>
-        <td>Sets center latitude to value N (range -90 to 90)</td>
+        <td>Sets center latitude to value N (range -90 to 90). Default is <span id='latdef'>zzz</span>.</td>
       </tr>
       <tr>
         <td>lon</td>
         <td>N</td>
-        <td>Sets center longitude to value N (range -180 to 180)</td>
+        <td>Sets center longitude to value N (range -180 to 180). Default is <span id='londef'>zzz</span>.</td>
       </tr>
       <tr>
         <td>z</td>
         <td>N</td>
-        <td>Sets zoom value to N (range 1 to 18)</td>
+        <td>Sets zoom value to N (range 2.5 to 15). Default is <span id='zdef'>zzz</span>.</td>
       </tr>
       <tr>
         <td>smartstep</td>
         <td>on|off</td>
-        <td>Enables or disables the smart step feature.</td>
+        <td>Enables or disables the smart step feature. Default is <span id='stepdef'>zzz</span>.</td>
+      </tr>
+      <tr>
+        <td>background</td>
+        <td>relief|world|<br/>physical|white|<br/>stamen|streets|paint</td>
+        <td>Sets the background map to the given option. Default is "<span id='backdef'>zzz</span>".</td>
       </tr>
     </table>
     <p>

--- a/ohmec.css
+++ b/ohmec.css
@@ -70,6 +70,7 @@ h1 {
   border:solid;
   border-collapse: separate;
   border-spacing: 15px 0px;
+  background: #d8d8d8;
 }
 #directlink {
   font-family: "Courier";

--- a/time_slider.js
+++ b/time_slider.js
@@ -58,7 +58,13 @@ L.Control.TimeLineSlider = L.Control.extend({
     this.rangeObject = L.DomUtil.get(this.sliderDiv).children[0];
 
     this.sliderYears = L.DomUtil.create('ul', 'slider-years', this.sliderContainer);
-    this.sliderYears.innerHTML = "<li>" + this.options.timelineDateMin.getFullYear() + "</li><li>" + this.options.timelineDateMax.getFullYear() + "</li>";
+    let minYear = this.options.timelineDateMin.getFullYear();
+    let maxYear = this.options.timelineDateMax.getFullYear();
+    let absMinYear = minYear < 0 ? -1*minYear : minYear;
+    let absMaxYear = maxYear < 0 ? -1*maxYear : maxYear;
+    let minYearStr = absMinYear + ((minYear < 0) ? 'BC' : '');
+    let maxYearStr = absMaxYear + ((maxYear < 0) ? 'BC' : '');
+    this.sliderYears.innerHTML = "<li>" + minYearStr + "</li><li>" + maxYearStr + "</li>";
 
     this.advanceDiv = L.DomUtil.create('div', 'advance', this.sliderContainer);
     this.advanceDiv.innerHTML = '<input type="button" id="advButton" value="Advance"></input>';


### PR DESCRIPTION
More clean up to `index.html` page, including making option tables more readable; showing defaults for `&override` values; adding missing `&background=` override; preparing for BC dates by allowing BC input, and using BC suffix instead of negative years on dates.

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>