### PR TITLE
Add more keyboard shortcuts

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,21 @@
         <td>Modify underlying base map to use unlabeled watercolor "paint" map</td>
       </tr>
       <tr>
+        <td>a</td>
+        <td>
+          Toggles the advance button. Pressing the key is equivalent to pressing
+          the Advance button on the page, toggling either on or off depending
+          upon current status.
+        </td>
+      </tr>
+      <tr>
+        <td>r</td>
+        <td>
+          Resets the view to the default lat/lon/z settings, that is the default
+          of the database, or as overriden by URL parameters.
+        </td>
+      </tr>
+      <tr>
         <td>s</td>
         <td>
           Toggles the "smart step" button feature. When enabled (default true),
@@ -96,6 +111,31 @@
           to the next or previous change in the database.  NOTE the user must
           click on the map once to indicate focus on it (vs other browser items)
           before any keyboard event.
+        </td>
+      </tr>
+      <tr>
+        <td>z</td>
+        <td>
+          Zooms the viewing window to be the bounding box of the currently
+          active feature. This could be what is hovered over by the mouse,
+          or the currently selected feature "pinned" by the "i" button information
+          holding feature.
+        </td>
+      </tr>
+      <tr>
+        <td>&gt; or .</td>
+        <td>
+          Step forward. Equivalent to pressing the (Step +) button on the page.
+          The amount to step forward is under the management of the Smart Step
+          feature which may be on or off.
+        </td>
+      </tr>
+      <tr>
+        <td>&lt; or ,</td>
+        <td>
+          Step backward. Equivalent to pressing the (Step -) button on the page.
+          The amount to step backward is under the management of the Smart Step
+          feature which may be on or off.
         </td>
       </tr>
     </table>

--- a/ohmec.js
+++ b/ohmec.js
@@ -37,6 +37,7 @@ let backgroundLayerSetting = backgroundLayerDefault;
 let backgroundLayers = {};
 let maxZoomPerBackground = {};
 let lastBackgroundLayer;
+let lastLayer;
 
 for(let param of parameters) {
   let test = /(startdatestr|enddatestr|curdatestr)=([-?\d:BC]+)/;
@@ -285,6 +286,7 @@ function highlightFeature(e) {
       layer.bringToFront();
     }
   }
+  lastLayer = layer;
 
   infobox.update(layer.feature.id,layer.feature.properties);
 }
@@ -292,6 +294,7 @@ function highlightFeature(e) {
 function resetHighlight(e) {
   geojson.resetStyle(e.target);
   infobox.update(held_id,held_prop);
+  lastLayer = undefined;
 }
 
 // upon mouse click, hold the information, allowing the
@@ -697,42 +700,40 @@ updateHTML('backdef',   backgroundLayerDefault);
 updateHTML('polycount', polygonCount);
 spanPtr = document.querySelector('#startdef');
 
-// upon keypress, if on a feature, hold its information, allowing the
-// user to click on the source link. so as to not linger forever,
-// hold the information about a few seconds.
+// check keypress value to determine function.
 function checkKeypress(e) {
   let backgroundUpdated = false;
-  if (e.originalEvent.key === '0') {
-    backgroundLayerSetting = 'relief';
-    backgroundUpdated = true;
-  }
-  if (e.originalEvent.key === '1') {
-    backgroundLayerSetting = 'world';
-    backgroundUpdated = true;
-  }
-  if (e.originalEvent.key === '2') {
-    backgroundLayerSetting = 'physical';
-    backgroundUpdated = true;
-  }
-  if (e.originalEvent.key === '3') {
-    backgroundLayerSetting = 'white';
-    backgroundUpdated = true;
-  }
-  if (e.originalEvent.key === '4') {
-    backgroundLayerSetting = 'stamen';
-    backgroundUpdated = true;
-  }
-  if (e.originalEvent.key === '5') {
-    backgroundLayerSetting = 'streets';
-    backgroundUpdated = true;
-  }
-  if (e.originalEvent.key === '6') {
-    backgroundLayerSetting = 'paint';
-    backgroundUpdated = true;
-  }
-  if (e.originalEvent.key === 's') {
-    smartStepFeature = 1 - smartStepFeature;
-    timelineSlider.updateButtons(smartStepFeature);
+  switch(e.originalEvent.key) {
+    case '0': backgroundLayerSetting = 'relief';   backgroundUpdated = true; break;
+    case '1': backgroundLayerSetting = 'world';    backgroundUpdated = true; break;
+    case '2': backgroundLayerSetting = 'physical'; backgroundUpdated = true; break;
+    case '3': backgroundLayerSetting = 'white';    backgroundUpdated = true; break;
+    case '4': backgroundLayerSetting = 'stamen';   backgroundUpdated = true; break;
+    case '5': backgroundLayerSetting = 'streets' ; backgroundUpdated = true; break;
+    case '6': backgroundLayerSetting = 'paint';    backgroundUpdated = true; break;
+    case 'a':
+      timelineSlider.affectAdvance();
+      break;
+    case 'r':
+      ohmap.setView([latSettingStart, lonSettingStart],zoomSettingStart);
+      break;
+    case 's':
+      smartStepFeature = 1 - smartStepFeature;
+      timelineSlider.updateButtons(smartStepFeature);
+      break;
+    case 'z':
+      if(lastLayer) {
+        ohmap.fitBounds(lastLayer.getBounds());
+      }
+      break;
+    case '>':
+    case '.':
+      timelineSlider.affectStepF();
+      break;
+    case '<':
+    case ',':
+      timelineSlider.affectStepR();
+      break;
   }
   if (backgroundUpdated) {
     lastBackgroundLayer.remove();

--- a/time_slider.js
+++ b/time_slider.js
@@ -103,7 +103,7 @@ L.Control.TimeLineSlider = L.Control.extend({
       timelineSlider.options.updateTime({dateValue: timelineSlider.rangeObject.value});
     }
 
-    L.DomEvent.on(timelineSlider.advButtonObject, "click", function() {
+    timelineSlider.affectAdvance = function() {
       if(timelineSlider.advButtonObject.value == "Advance") {
         timelineSlider.advButtonObject.value = "Stop";
         timelineSlider.intervalFunc = setInterval(timelineSlider.advanceTime, 250);
@@ -111,13 +111,16 @@ L.Control.TimeLineSlider = L.Control.extend({
         timelineSlider.advButtonObject.value = "Advance";
         clearInterval(timelineSlider.intervalFunc);
       }
-    });
+    }
 
-    L.DomEvent.on(timelineSlider.stepFButtonObject, "click", function() {
-      // step time forward once in datesOfInterest array
-      // if "smartStep" feature is turned on, only step forward
-      // if something in the field of view has changed for that step,
-      // else skip to the next one
+    L.DomEvent.on(timelineSlider.advButtonObject, "click", timelineSlider.affectAdvance);
+
+    // step time forward once in datesOfInterest array
+    // if "smartStep" feature is turned on, only step forward
+    // if something in the field of view has changed for that step,
+    // else skip to the next one
+
+    timelineSlider.affectStepF = function() {
       let curTime = timelineSlider.rangeObject.value;
       for (let i=1;i<datesOfInterestSorted.length;i++) {
         if (curTime < datesOfInterestSorted[i].getTime()) {
@@ -148,14 +151,15 @@ L.Control.TimeLineSlider = L.Control.extend({
           }
         }
       }
-    });
+    }
 
-    L.DomEvent.on(timelineSlider.stepRButtonObject, "click", function() {
-      // step time backward once in datesOfInterest array.
-      // if "smartStep" feature is turned on, only step backward
-      // if something in the field of view has changed for the next step
-      // (indicating that something will be removed in this one) else skip
-      // to the previous one
+    // step time backward once in datesOfInterest array.
+    // if "smartStep" feature is turned on, only step backward
+    // if something in the field of view has changed for the next step
+    // (indicating that something will be removed in this one) else skip
+    // to the previous one
+
+    timelineSlider.affectStepR = function() {
       let curTime = timelineSlider.rangeObject.value;
       for (let i=datesOfInterestSorted.length-2;i>=0;i--) {
         if (curTime > datesOfInterestSorted[i].getTime()) {
@@ -186,7 +190,10 @@ L.Control.TimeLineSlider = L.Control.extend({
           }
         }
       }
-    });
+    }
+
+    L.DomEvent.on(timelineSlider.stepFButtonObject, "click", timelineSlider.affectStepF);
+    L.DomEvent.on(timelineSlider.stepRButtonObject, "click", timelineSlider.affectStepR);
 
     // Initialize input change at start
     let inputEvent = new Event('input');


### PR DESCRIPTION
Fixes #127 

Fixes #134 

This adds the `zoom to Feature` request of #127 with keypress value of `z`, as well as giving keyboard shortcuts for the buttons `Step +` (`>` or `.`), `Step -` (`<` or `,`), and advance (`a`) toggle. In addition, to fix feature request #134, this adds `r` to reset to initial lat/lon/z settings.

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>