### PR TITLE
Adding `?nl` feature to enable native_lands.ca information

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,6 +212,7 @@
     </p>
 
     <script type="text/javascript" src="ohmec_data_na.js"></script>
+    <script type="text/javascript" src="ohmec_data_nl.js"></script>
     <script type="text/javascript" src="ohmec_data_eur.js"></script>
     <script type="text/javascript" src="time_slider.js"></script>
     <script type="text/javascript" src="geo_features.js"></script>

--- a/ohmec_data_na.js
+++ b/ohmec_data_na.js
@@ -105,7 +105,7 @@ dataNA = {
       "match":{ "entity1name": "Panama"},
       "style":{ "strokeColor": "#c80015", "fillColor": "#092088"}},
     { "type": "match",
-      "match":{ "entity1name": "Canada"},
+      "match":{ "entity1name": "Canada", "entity2type": "territory"},
       "style":{ "strokeColor": "#ffffff", "fillColor": "#ff8095"}},
     { "type": "match",
       "match":{ "entity1name": "Cuba"},


### PR DESCRIPTION
This completes the job started in #154 and abandoned since the database had moved quite a bit.

This gives a command-line option (using `?nl`) to visualize the data from `native_lands.ca`. For now I would like to leave it unadvertised until a) we have a discussion with them about how they would like to see; b) we document it better; c) we add a pop-up when selected that gives the correct credit. For now this is for our internal viewing to discuss and agree upon the style.

@warrenjp LMKWYT

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>