### PR TITLE
Allow Points of Interest to be entity2

### DIFF
--- a/ohmec.js
+++ b/ohmec.js
@@ -604,6 +604,11 @@ function onEachFeature(feature, layer) {
        feature.properties.entity1type === 'battle') {
       iconFile = 'poi_' + feature.properties.entity1type + '.svg';
     }
+    if(feature.properties.entity2type === 'settlement'  ||
+       feature.properties.entity2type === 'archaeology' ||
+       feature.properties.entity2type === 'battle') {
+      iconFile = 'poi_' + feature.properties.entity2type + '.svg';
+    }
 
     let iconElementBounds = [ [ plat+iconSize/2, plon-iconSize/2 ], [ plat-iconSize/2, plon+iconSize/2 ] ];
     feature.iconOverlay = L.imageOverlay(iconFile, iconElementBounds, { zIndex: 300 });


### PR DESCRIPTION
Addresses #166 

This allows Points of Interest to be in the `entity2` property. It does not yet color them with the `entity1`s style information, which is the second half of #166 so leaving it open still for that feature upgrade.

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>