### PR TITLE
Animate stroke and fill colors and opacities

### DIFF
--- a/ohmec_data_eur.js
+++ b/ohmec_data_eur.js
@@ -345,6 +345,12 @@ dataEur = {
         "fidelity":1,
         "startdatestr":"-9700",
         "enddatestr":"-9500"},
+      "style":{
+        "strokeColor": "#008040",
+        "fillColor":   "#00ffcc",
+        "strokeOpacity": 0.1,
+        "fillOpacity":   0.1,
+        "strokeWeight":  5.0},
       "geometry":{
         "type":"Polygon",
         "coordinates":[


### PR DESCRIPTION
Fixes #182 

This adds animation ability to morph colors and opacities. This can be useful when moving from one ancient "culture" to another without looking like a step function from, say, Magdalenian Culture to Ahrensburg Culture. I've included one example in the European play area (`?easter`) but doesn't really take advantage of the conversion just yet, only used for debugging purposes.

Unrelated: clipping BC dates to ignore day and month, only using year.

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>