### PR TITLE
Add layerDepth property

### DIFF
--- a/ohmec.js
+++ b/ohmec.js
@@ -916,6 +916,7 @@ function geo_lint(dataset, convertFromNativeLands, replaceIndigenous, applyChero
         f.style.fillOn = true;
         f.style.fillOpacity = 0.1;
         f.style.borderless = false;
+        f.style.layerDepth = "default";
       } else if("styles" in dataset) {
         if("style" in f) {
           f.stylehold = f.style;
@@ -1246,6 +1247,20 @@ geojson.evaluateLayers = function () {
         lyr.feature.iconOverlay.removeFrom(ohmap);
       }
       lyr.feature.textOverlay.removeFrom(ohmap);
+    }
+  }
+  // now check for layer control problems (front and back, ignore default)
+  for(let l in this._layers) {
+    let lyr = this._layers[l];
+    let prop = lyr.feature.properties;
+    let style = lyr.feature.style;
+    if(curDate >= prop.startDate && curDate <= prop.endDate && "layerDepth" in style && style.layerDepth !== "default") {
+      if(style.layerDepth === "front") {
+        lyr.bringToFront();
+      }
+      if(style.layerDepth === "back") {
+        lyr.bringToBack();
+      }
     }
   }
 }

--- a/ohmec_data_eur.js
+++ b/ohmec_data_eur.js
@@ -12,6 +12,7 @@ dataEur = {
         "strokeWeight":  2.0,
         "strokeDash":    1,
         "borderless":    false,
+        "layerDepth":    "default",
         "fillOn":        true,
         "fillColor":     "#c0c0c0",
         "fillOpacity":   0.6,
@@ -34,7 +35,7 @@ dataEur = {
       "style":{ "strokeColor": "#80b070", "fillColor": "#c8e8b0"}},
     { "type": "match",
       "match":{ "entity1type": "geography", "entity1name": "icecap"},
-      "style":{ "strokeColor": "#e0e0ff", "fillColor": "#f4f4ff", "strokeWeight": 1.0, "fillOpacity": 0.9}}],
+      "style":{ "strokeColor": "#e0e0ff", "fillColor": "#f4f4ff", "strokeWeight": 1.0, "fillOpacity": 0.9, "layerDepth": "back"}}],
   "features":[
     { "type":"Feature",
       "id":"Olmec00",

--- a/ohmec_data_na.js
+++ b/ohmec_data_na.js
@@ -12,6 +12,7 @@ dataNA = {
         "strokeWeight":  1.5,
         "strokeDash":    "",
         "borderless":    false,
+        "layerDepth":    "default",
         "fillOn":        true,
         "fillColor":     "#c0c0c0",
         "fillOpacity":   0.6,


### PR DESCRIPTION
Fixes #184 

This adds `layerDepth` as a style element, rather than a property as suggested in #184. This allows the style property to be inherited for all types. It is envisioned as being used by `geography` types such as land bridges that appeared in Pleistocene times.

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>