### PR TITLE
add iconScale and noLabel properties

### DIFF
--- a/ohmec.js
+++ b/ohmec.js
@@ -549,10 +549,10 @@ function getTextLabel(bounds, id, label, isPoint, properties, fontinfo, altPrope
 }
 
 function getFeatureLabel(feature) {
-  if("entity2name" in feature.properties) {
+  if("noLabel" in feature.properties && feature.properties.noLabel) {
+    return ""
+  } else if("entity2name" in feature.properties) {
     return feature.properties.entity2name;
-  } else if(feature.properties.entity1type === 'geography' && feature.properties.entity1name === 'icecap') {
-    return ' '
   } else {
     return feature.properties.entity1name;
   }
@@ -609,6 +609,13 @@ function onEachFeature(feature, layer) {
     let plat = coords[1];
     let iconSize = 0.05;  // arbitraty size of icon, 0.05 degrees
     let bboxSize = 1.0;   // arbitraty size of label bounding box, 1 degree
+
+    // allow the icon and label box to be scaled
+    if("iconScale" in feature.properties) {
+      iconSize = iconSize * feature.properties.iconScale;
+      bboxSize = bboxSize * feature.properties.iconScale;
+    }
+
     let iconElementBounds = [ [ plat+iconSize/2, plon-iconSize/2 ], [ plat-iconSize/2, plon+iconSize/2 ] ];
     let poiType = "poi";
     let fillColor = "#c0c0ff";

--- a/ohmec_data_eur.js
+++ b/ohmec_data_eur.js
@@ -76,6 +76,7 @@ dataEur = {
       "properties":{
         "entity1type":"geography",
         "entity1name":"icecap",
+        "noLabel":true,
         "animateTo":"Icecap15000BC",
         "editdatestr":"2021:11:08",
         "source":"http://metrocosm.com/timelapse-evolution-of-earths-surface",
@@ -91,6 +92,7 @@ dataEur = {
       "properties":{
         "entity1type":"geography",
         "entity1name":"icecap",
+        "noLabel":true,
         "animateTo":"Icecap14000BC",
         "editdatestr":"2021:11:08",
         "source":"http://metrocosm.com/timelapse-evolution-of-earths-surface",
@@ -106,6 +108,7 @@ dataEur = {
       "properties":{
         "entity1type":"geography",
         "entity1name":"icecap",
+        "noLabel":true,
         "animateTo":"Icecap13000BC",
         "editdatestr":"2021:11:08",
         "source":"http://metrocosm.com/timelapse-evolution-of-earths-surface",
@@ -121,6 +124,7 @@ dataEur = {
       "properties":{
         "entity1type":"geography",
         "entity1name":"icecap",
+        "noLabel":true,
         "animateTo":"Icecap12000BC",
         "editdatestr":"2021:11:08",
         "source":"http://metrocosm.com/timelapse-evolution-of-earths-surface",
@@ -136,6 +140,7 @@ dataEur = {
       "properties":{
         "entity1type":"geography",
         "entity1name":"icecap",
+        "noLabel":true,
         "animateTo":"Icecap11000BC",
         "editdatestr":"2021:11:08",
         "source":"http://metrocosm.com/timelapse-evolution-of-earths-surface",
@@ -151,6 +156,7 @@ dataEur = {
       "properties":{
         "entity1type":"geography",
         "entity1name":"icecap",
+        "noLabel":true,
         "animateTo":"Icecap10000BC",
         "editdatestr":"2021:11:08",
         "source":"http://metrocosm.com/timelapse-evolution-of-earths-surface",
@@ -166,6 +172,7 @@ dataEur = {
       "properties":{
         "entity1type":"geography",
         "entity1name":"icecap",
+        "noLabel":true,
         "animateTo":"Icecap09000BC",
         "editdatestr":"2021:11:08",
         "source":"http://metrocosm.com/timelapse-evolution-of-earths-surface",
@@ -181,6 +188,7 @@ dataEur = {
       "properties":{
         "entity1type":"geography",
         "entity1name":"icecap",
+        "noLabel":true,
         "animateTo":"Icecap08000BC",
         "editdatestr":"2021:11:08",
         "source":"http://metrocosm.com/timelapse-evolution-of-earths-surface",
@@ -196,6 +204,7 @@ dataEur = {
       "properties":{
         "entity1type":"geography",
         "entity1name":"icecap",
+        "noLabel":true,
         "animateTo":"Icecap07500BC",
         "editdatestr":"2021:11:08",
         "source":"http://metrocosm.com/timelapse-evolution-of-earths-surface",
@@ -211,6 +220,7 @@ dataEur = {
       "properties":{
         "entity1type":"geography",
         "entity1name":"icecap",
+        "noLabel":true,
         "animateTo":"Icecap07000BC",
         "editdatestr":"2021:11:08",
         "source":"http://metrocosm.com/timelapse-evolution-of-earths-surface",
@@ -226,6 +236,7 @@ dataEur = {
       "properties":{
         "entity1type":"geography",
         "entity1name":"icecap",
+        "noLabel":true,
         "animateTo":"Icecap06500BC",
         "editdatestr":"2021:11:08",
         "source":"http://metrocosm.com/timelapse-evolution-of-earths-surface",
@@ -241,6 +252,7 @@ dataEur = {
       "properties":{
         "entity1type":"geography",
         "entity1name":"icecap",
+        "noLabel":true,
         "animateTo":"Icecap06000BC",
         "editdatestr":"2021:11:08",
         "source":"http://metrocosm.com/timelapse-evolution-of-earths-surface",
@@ -256,6 +268,7 @@ dataEur = {
       "properties":{
         "entity1type":"geography",
         "entity1name":"icecap",
+        "noLabel":true,
         "animateTo":"Icecap05000BC",
         "editdatestr":"2021:11:08",
         "source":"http://metrocosm.com/timelapse-evolution-of-earths-surface",
@@ -271,6 +284,7 @@ dataEur = {
       "properties":{
         "entity1type":"geography",
         "entity1name":"icecap",
+        "noLabel":true,
         "editdatestr":"2021:11:08",
         "source":"http://metrocosm.com/timelapse-evolution-of-earths-surface",
         "fidelity":2,
@@ -399,6 +413,8 @@ dataEur = {
         "editdatestr":"2021:11:09",
         "source":"https://en.wikipedia.org/wiki/Cave_of_Altamira",
         "fidelity":3,
+        "iconScale":10.0,
+        "labelY":3,
         "startdatestr":"-14590",
         "enddatestr":"-12000"},
       "geometry":{
@@ -504,6 +520,8 @@ dataEur = {
         "editdatestr":"2021:11:09",
         "source":"https://www.sciencedirect.com/science/article/pii/S1040618214002006?via%3Dihub",
         "fidelity":3,
+        "iconScale":7.0,
+        "labelY":4,
         "startdatestr":"-8400",
         "enddatestr":"-6000"},
       "geometry":{
@@ -517,6 +535,8 @@ dataEur = {
         "editdatestr":"2021:11:09",
         "source":"https://www.sciencedirect.com/science/article/pii/S1040618214002006?via%3Dihub",
         "fidelity":3,
+        "iconScale":7.0,
+        "labelY":4,
         "startdatestr":"-8280",
         "enddatestr":"-6000"},
       "geometry":{
@@ -530,6 +550,8 @@ dataEur = {
         "editdatestr":"2021:11:09",
         "source":"https://en.natmus.dk/historical-knowledge/denmark/prehistoric-period-until-1050-ad/the-mesolithic-period/the-aurochs-from-vig",
         "fidelity":3,
+        "iconScale":7.0,
+        "labelY":4,
         "startdatestr":"-8050",
         "enddatestr":"-7500"},
       "geometry":{


### PR DESCRIPTION
fixes #186 
fixes #187

This adds two new properties: `iconScale` and `noLabel`. This allows POI point icons to be scale (their labels with them), and for the database to declare that an entity shouldn't have a label.

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>