### PR TITLE
Override start/end date in db, advance parameters in URL

### DIFF
--- a/ohmec.js
+++ b/ohmec.js
@@ -13,6 +13,8 @@ let timelineDateMinDefault = today;                 // these are the calculated 
 let timelineDateMaxDefault = new Date(1000,0,1);
 let timelineDateMinOverride;                        // these allow the database to change timeline range
 let timelineDateMaxOverride;                        // unless provided in the URL override parameters
+let timelineIntervalCount = 240;
+let timelineIntervalDuration = 250;                 // milliseconds
 
 let latSettingDefault = 38.5;                       // centering around USA region for this Phase
 let lonSettingDefault = -98.0;
@@ -97,12 +99,19 @@ for(let param of parameters) {
   if (match !== null) {
     backgroundLayerSetting = match[1];
   }
+  test = /advInt=(\d+)/;
+  match = param.match(test);
+  if (match !== null && match[1] !== 0) {
+    timelineIntervalCount = match[1];
+  }
+  test = /advDur=(\d+)/;
+  match = param.match(test);
+  if (match !== null && match[1] !== 0) {
+    timelineIntervalDuration = match[1];
+  }
   test = /easter/;
   match = param.match(test);
   if (match !== null) {
-    timelineDateMinOverride = str2date('15000BC',false);
-    timelineDateMaxOverride = str2date( '6000BC',true);
-    timelineDateStart       = str2date('14500BC',false);
     latSettingStart = 48;
     lonSettingStart =  3;
     zoomSettingStart = 4;
@@ -802,6 +811,15 @@ function geo_lint(dataset, convertFromNativeLands, replaceIndigenous, applyChero
   if(dataset.type !== "FeatureCollection") {
     throw "expected dataset type === FeatureCollection, got " + dataset.type;
   }
+  if("startdatestr" in dataset && !timelineDateMinOverride) {
+    timelineDateMinOverride = str2date(dataset.startdatestr,false);
+  }
+  if("curdatestr" in dataset && timelineDateStart === timelineDateStartDefault) {
+    timelineDateStart = str2date(dataset.curdatestr,false);
+  }
+  if("enddatestr" in dataset && !timelineDateMaxOverride) {
+    timelineDateMaxOverride = str2date(dataset.enddatestr,true);
+  }
   if("features" in dataset) {
     for(let f of dataset.features) {
       let removeFeature = false;
@@ -1308,18 +1326,20 @@ let mapBounds = function() {
 }
 
 timelineSlider = L.control.timelineSlider({
-  timelineDateMin:         timelineDateMin,
-  timelineDateMax:         timelineDateMax,
-  timelineDateStart:       timelineDateStart,
-  infoboxHandle:           infobox,
-  smartStepFeature:        smartStepFeature,
-  clearInfobox:            infobox.clear,
-  idAddsPerDOI:            idAddsPerDOI,
-  idSubsPerDOI:            idSubsPerDOI,
-  boundsHash:              boundsHash,
-  mapBounds:               mapBounds,
-  datesOfInterestSorted:   datesOfInterestSorted,
-  updateTime:              refreshMap}).addTo(ohmap);
+  timelineDateMin:          timelineDateMin,
+  timelineDateMax:          timelineDateMax,
+  timelineDateStart:        timelineDateStart,
+  timelineIntervalCount:    timelineIntervalCount,
+  timelineIntervalDuration: timelineIntervalDuration,
+  infoboxHandle:            infobox,
+  smartStepFeature:         smartStepFeature,
+  clearInfobox:             infobox.clear,
+  idAddsPerDOI:             idAddsPerDOI,
+  idSubsPerDOI:             idSubsPerDOI,
+  boundsHash:               boundsHash,
+  mapBounds:                mapBounds,
+  datesOfInterestSorted:    datesOfInterestSorted,
+  updateTime:               refreshMap}).addTo(ohmap);
 
 // update HTML data
 function updateHTML(spanName, value) {

--- a/ohmec_data_eur.js
+++ b/ohmec_data_eur.js
@@ -3,6 +3,9 @@ dataEur = {
   "_comment2":"Licensed under the Apache License, Version 2.0, see LICENSE for details.",
   "_comment3":"SPDX-License-Identifier: Apache-2.0",
   "type":"FeatureCollection",
+  "startdatestr":"15000BC",
+  "curdatestr":  "14500BC",
+  "enddatestr":   "6000BC",
   "styles":[
     { "type": "default",
       "style":{

--- a/ohmec_data_na.js
+++ b/ohmec_data_na.js
@@ -3,6 +3,9 @@ dataNA = {
   "_comment2":"Licensed under the Apache License, Version 2.0, see LICENSE for details.",
   "_comment3":"SPDX-License-Identifier: Apache-2.0",
   "type":"FeatureCollection",
+  "startdatestr":"1600:01:01",
+  "curdatestr":  "1764:01:01",
+  "enddatestr":  "2010:12:31",
   "styles":[
     { "type": "default",
       "style":{

--- a/time_slider.js
+++ b/time_slider.js
@@ -13,11 +13,13 @@ function boundsIntersect(bounds1, bounds2) {
 
 L.Control.TimeLineSlider = L.Control.extend({
   options: {
-    position:           'bottomleft',
-    timelineDateMin:    new Date(1,0,1),
-    timelineDateMax:    new Date,
-    timelineDateStart:  new Date(1776,6,4),
-    sliderWidth:        "750px"
+    position:                 'bottomleft',
+    timelineDateMin:          new Date(1,0,1),
+    timelineDateMax:          new Date,
+    timelineDateStart:        new Date(1776,6,4),
+    timelineIntervalCount:    240,
+    timelineIntervalDuration: 250,
+    sliderWidth:              "750px"
   },
 
   initialize: function (options) {
@@ -94,7 +96,10 @@ L.Control.TimeLineSlider = L.Control.extend({
     // potentially "move time"
 
     thisSlider.advanceTime = function() {
-      let incrTime = (thisSlider.options.timelineDateMax.getTime() - thisSlider.options.timelineDateMin.getTime())/240;
+      let incrTime =
+        (thisSlider.options.timelineDateMax.getTime() -
+         thisSlider.options.timelineDateMin.getTime())/
+         thisSlider.options.timelineIntervalCount;
       let newTime = parseFloat(thisSlider.rangeObject.value) + parseFloat(incrTime);
       if(newTime >= thisSlider.options.timelineDateMax.getTime()) {
         newTime = thisSlider.options.timelineDateMax.getTime();
@@ -109,7 +114,7 @@ L.Control.TimeLineSlider = L.Control.extend({
     thisSlider.affectAdvance = function() {
       if(thisSlider.advButtonObject.value == "Advance") {
         thisSlider.advButtonObject.value = "Stop";
-        thisSlider.intervalFunc = setInterval(thisSlider.advanceTime, 250);
+        thisSlider.intervalFunc = setInterval(thisSlider.advanceTime, thisSlider.options.timelineIntervalDuration);
       } else {
         thisSlider.advButtonObject.value = "Advance";
         clearInterval(thisSlider.intervalFunc);


### PR DESCRIPTION
Fixes #189 
Fixes #190 

This patch allows the user to override the default parameters for the Advance button, which are 240 intervals of 250ms, for a total advance of 2 minutes. New parameters `?advInt=n` and `?advDur=m` change the number of intervals to `n`, and the duration of the intervals to `m` milliseconds, respectively.

In addition, this patch allows the database to override the default start, current, and end times for the timeline slider. They are still overrideable by the URL modifiers. The `_data_na` and `_data_eur` databases set their appropriate values.

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>