### PR TITLE
Add ability to set default lat/lon/z from database

### DIFF
--- a/ohmec.js
+++ b/ohmec.js
@@ -27,7 +27,8 @@ let lonSettingMax = 180.0;
 
 let zoomSettingMin = 2.5;
 let zoomSettingMax = 15.0;
-let zoomSettingStart = 4.5;
+let zoomSettingDefault = 4.5;
+let zoomSettingStart = zoomSettingDefault;
 
 let boundsHash = {};
 let smartStepDefault = 1;
@@ -112,9 +113,6 @@ for(let param of parameters) {
   test = /easter/;
   match = param.match(test);
   if (match !== null) {
-    latSettingStart = 48;
-    lonSettingStart =  3;
-    zoomSettingStart = 4;
     useEurope = true;
   }
   test = /nl/;
@@ -493,7 +491,7 @@ function getTextLabel(bounds, id, label, isPoint, properties, fontinfo, altPrope
     }
   }
 
-  let fontsize = isPoint ? fontinfo.scale/25 : fontinfo.scale/labelLength;
+  let fontsize = isPoint ? fontinfo.scale/25 : labelLength ? fontinfo.scale/labelLength : 1;
   fontsize *= labelScale;
 
   let inner = '';
@@ -820,6 +818,16 @@ function geo_lint(dataset, convertFromNativeLands, replaceIndigenous, applyChero
   if("enddatestr" in dataset && !timelineDateMaxOverride) {
     timelineDateMaxOverride = str2date(dataset.enddatestr,true);
   }
+  if("defaultLat" in dataset && latSettingStart === latSettingDefault) {
+    latSettingStart = dataset.defaultLat;
+  }
+  if("defaultLon" in dataset && lonSettingStart === lonSettingDefault) {
+    lonSettingStart = dataset.defaultLon;
+  }
+  if("defaultZ" in dataset && zoomSettingStart === zoomSettingDefault) {
+    zoomSettingStart = dataset.defaultZ;
+  }
+  ohmap.setView([latSettingStart, lonSettingStart],zoomSettingStart);
   if("features" in dataset) {
     for(let f of dataset.features) {
       let removeFeature = false;

--- a/ohmec_data_eur.js
+++ b/ohmec_data_eur.js
@@ -6,6 +6,9 @@ dataEur = {
   "startdatestr":"15000BC",
   "curdatestr":  "14500BC",
   "enddatestr":   "6000BC",
+  "defaultLat":       48.0,
+  "defaultLon":        3.0,
+  "defaultZ":          4.0,
   "styles":[
     { "type": "default",
       "style":{

--- a/ohmec_data_na.js
+++ b/ohmec_data_na.js
@@ -6,6 +6,9 @@ dataNA = {
   "startdatestr":"1600:01:01",
   "curdatestr":  "1764:01:01",
   "enddatestr":  "2010:12:31",
+  "defaultLat":  38.5,
+  "defaultLon": -98.0,
+  "defaultZ":     4.5,
   "styles":[
     { "type": "default",
       "style":{


### PR DESCRIPTION
Fixes #189 

This adds the new functionality added by the reopened #189, ability to set default lat/lon/z from the database so that it doesn't have to be baked into the `ohmec.js` script.

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>