### PR TITLE
Add ability to make popups for any dataset

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
       for more insight into the project. A specification of the
       <a href="https://docs.google.com/document/d/15D9t61Y1WYYH02BuIp3C8InJD40L19uHIcPNDfNv0Bk/edit?usp=sharing">extended GeoJSON</a>
       format that underpins the historical database is provided here.
+      For information or any questions, please use <a href="mailto:ohmec.contact@gmail.com">ohmec.contact@gmail.com</a>.
     </p>
     <p>
       Holding the shift key down and creating a bounding box will redefine
@@ -201,6 +202,62 @@
         <td>background</td>
         <td>relief|world|<br/>physical|white|<br/>stamen|streets|paint</td>
         <td>Sets the background map to the given option. Default is "<span id='backdef'>zzz</span>".</td>
+      </tr>
+    </table>
+    <p>
+      Special arguments can be provided to view <b>special historical
+      studies</b> or particular viewing modes.  These arguments are shown below,
+      and are set as for example
+      <font size="4" face="Courier"><b>https://ohmec.github.io/ohmec/index.html?param</b></font>.
+    </p>
+    <table id="paramtable" hborder=1>
+      <tr>
+        <th>parameter</th>
+        <th>description</th>
+      </tr>
+      <tr>
+        <td>aa</td>
+        <td>
+          The `?aa` argument highlights a study of the "Ancient Americas".
+          This study focused on the ancient prehistoric movements of peoples into
+          the Americas, as best we know through modern scholarship. The study at
+          this time focuses on the years 22000BC to 10000BC, following the movements
+          of the Ancient North Eurasians into Beringia, then the split of the
+          Southern Native Americans (SNA) along the Pacific Coast, and the Northern
+          Native Americans (NNA, aka Clovis Culture) through the parting of the
+          Canadian ice sheets. The fidelity of the mapping is highly speculative
+          and is shown for educational visualization purposes.
+        </td>
+      </tr>
+      <tr>
+        <td>cherokee</td>
+        <td>
+          The `?cherokee` argument highlights the movements of the Proto-
+          Cherokee and Cherokee tribes through the period 800BC to present. All other
+          Native tribes are absent in this study. Eventually it is desired to have
+          information on all Native tribes in this fasion, but this was made possible
+          by a 1990s archaeological study.
+        </td>
+      </tr>
+      <tr>
+        <td>nl</td>
+        <td>
+          The `?nl` argument swaps out the OHMEC Native tribal locations and
+          uses data from the organization <a href="http://native-land.ca">Native Land
+          Digital</a>. This is a richer dataset that has boundaries that encompass all
+          of the tribes' known homelands throughout their history. OHMEC would like to
+          work with Native Land Digital to attempt to represent movements of the tribes
+          akin to the Cherokee study.
+        </td>
+      </tr>
+      <tr>
+        <td>viking</td>
+        <td>
+          The `?viking` argument shows a brief highlight of pre-Viking peoples
+          in the northern European arena from roughly 15000BC to 6000BC. This was an
+          early experiement with modeling tribal movements as well as the effect of
+          geographical changes in the form of receding ice sheets.
+        </td>
       </tr>
     </table>
     <p>

--- a/ohmec.css
+++ b/ohmec.css
@@ -45,11 +45,11 @@ h1 {
   background-color: rgba(4,112,255,0.7);
   color: #eee;
 }
-#nlpopup {
+#popup {
   font: 16px New Tegomin, sans-serif;
   color: #eee;
 }
-#nlpopup a:link {
+#popup a:link {
   color: #eee;
 }
 .curdate {

--- a/ohmec_data_ancient_americas.js
+++ b/ohmec_data_ancient_americas.js
@@ -9,6 +9,11 @@ dataAA = {
   "defaultLat":       45.0,
   "defaultLon":     -115.0,
   "defaultZ":          3.5,
+  "popup": {
+    "text":"<p>This study of the Ancient American past is a highly speculative visualization of movements of a variety of peoples, and is roughly following the work of Dr Michael Waters and his team at Texas A&amp;M. The visualization begins with the splitting of the Ancient Berigians (AB) from the Ancient North Eurasians (ANE) around 20000BC. After the Beringian Standstill, a group - the Southern Native Americans (SNA) - is postulated to have split off and migrated down the Pacific Coast. A second group - the Northern Native Americans - separates and populates North America via the split in the Canadian ice sheets, to become the Clovis Culture. This work is currently un-corroborated and simply goes off public researched published by Texas A&amp;M and others.</p>",
+    "startdatestr":"22000BC",
+    "enddatestr":"10000BC"
+  },
   "styles":[
     { "type": "default",
       "style":{

--- a/ohmec_data_eur.js
+++ b/ohmec_data_eur.js
@@ -9,6 +9,11 @@ dataEur = {
   "defaultLat":       48.0,
   "defaultLon":        3.0,
   "defaultZ":          4.0,
+  "popup": {
+    "text":"<p>This micro-study of the pre-Viking peoples is simply used to visualize the movements of those people with respect to the receding ice sheets of the late Pleistocene age. The purpose was primarily for testing the animation abilities and has been set aside for the time being.</p>",
+    "startdatestr":"15000BC",
+    "enddatestr":"6000BC"
+  },
   "styles":[
     { "type": "default",
       "style":{

--- a/ohmec_data_nl.js
+++ b/ohmec_data_nl.js
@@ -1,5 +1,10 @@
 dataNL = {
 	"type": "FeatureCollection",
+  "popup": {
+    "text":"<p>Data of the indigenous peoples is provided by <a href=\"http://native-land.ca\">Native Land Digital</a> organization. See their website for more information. The map does not represent or intend to represent official or legal boundaries. The map is not perfect - it is a work in progress with many contributors.</p><p>The dates have been added by OHMEC temporarily as from approximately 700 - 1768AD. OHMEC will work with Native Land Digital to attempt to represent movements of the Native American tribes throughout their history.</p>",
+    "startdatestr":"700:01:01",
+    "enddatestr":"1768:12:31"
+  },
 	"features": [{
 		"type": "Feature",
 		"properties": {


### PR DESCRIPTION
Fixes #197 

This adds the ability to put popup information into a database, rather than in the primary Javascript file(s). It moves the Native Lands popup into that database, and adds a popup for the European and Ancient Americas data sets too. In addition, this adds some information to the `index.html` webpage to describe the different studies.

Signed-off-by: Scott Johnson <sjcupertino@gmail.com>