### PR TITLE
add ability to create coordinate_copy

### DIFF
--- a/ohmec.js
+++ b/ohmec.js
@@ -971,6 +971,14 @@ function geo_lint(dataset, convertFromNativeLands, replaceIndigenous, applyChero
           if(!applyCherokeeExample && p.entity1type === 'tribe' && p.entity1name.match(/Cherokee/)) {
             removeFeature = true;
           }
+          if("coordinate_copy" in f.geometry) {
+            if(f.geometry.coordinate_copy in fHash) {
+              console.log("copying coordinates from " + f.geometry.coordinate_copy + " to " + f.id);
+              f.geometry.coordinates = fHash[f.geometry.coordinate_copy].geometry.coordinates;
+            } else {
+              throw "can't copy coordinates from " + f.geometry.coordinate_copy + " for " + f.id;
+            }
+          }
         }
       } else {
         throw "no properties in feature " + f.id;
@@ -1088,8 +1096,20 @@ function prepare_animations() {
         }
       }
     } else if(fromF.geometry.type === 'Polygon') {
-      let fromC = fromF.geometry.coordinates[0];
-      let destC = destF.geometry.coordinates[0];
+      let fromC, destC;
+      if("coordinates" in fromF.geometry) {
+        fromC = fromF.geometry.coordinates[0];
+      } else {
+        throw "can't animate from " + id_from + " to " + animationHash[id_from] + " since no coordinates for " + id_from;
+      }
+      if("coordinates" in destF.geometry) {
+        if (!destF.geometry.coordinates) {
+          throw "can't animate from " + id_from + " to " + animationHash[id_from] + " since no coordinates for " + animationHash[id_from];
+        }
+        destC = destF.geometry.coordinates[0];
+      } else {
+        throw "can't animate from " + id_from + " to " + animationHash[id_from] + " since no coordinates for " + animationHash[id_from];
+      }
       if (fromC.length != destC.length) {
         throw "can't animate from " + id_from + " to " + animationHash[id_from] + " since coordinate lengths differ (" + fromC.length + " vs " + destC.length + ")";
       }

--- a/utilities/check_boundaries.py
+++ b/utilities/check_boundaries.py
@@ -159,12 +159,25 @@ overlap_count = 0
 gap_count = 0
 point_count = 0
 
+def get_shape(thisfeat):
+  thisid = thisfeat["id"]
+  if "coordinate_copy" in thisfeat["geometry"]:
+    copyname = thisfeat["geometry"]["coordinate_copy"]
+    if copyname in geoms:
+      return geoms[copyname]
+    else:
+      sys.stderr.write("can't handle out of order coordinate copies at this time.\n")
+      sys.stderr.write(thisid + " needs copy from " + copyname + "\n")
+      sys.exit(2)
+  else:
+    return shapely.geometry.asShape(thisfeat["geometry"])
+
 for feat1 in fullstruct["features"]:
   id1 = feat1["id"]
   props1 = feat1["properties"]
   if feat1["geometry"]["type"] == "Polygon" or feat1["geometry"]["type"] == "MultiPolygon":
     if id1 not in geoms:
-      geoms[id1] = shapely.geometry.asShape(feat1["geometry"])
+      geoms[id1] = get_shape(feat1)
       check_props(feat1)
       if not geoms[id1].is_valid:
         print(id1 + " is not valid\n")
@@ -182,7 +195,7 @@ for feat1 in fullstruct["features"]:
         if idAB not in already_handled:
           props2 = feat2["properties"]
           if id2 not in geoms:
-            geoms[id2] = shapely.geometry.asShape(feat2["geometry"])
+            geoms[id2] = get_shape(feat2)
             check_props(feat2)
             if not geoms[id2].is_valid:
               print(id2 + " is not valid\n")

--- a/utilities/merge_geometry.py
+++ b/utilities/merge_geometry.py
@@ -41,8 +41,21 @@ varjson = fm.group(2)
 fullstruct = json.loads(varjson)
 geoms = {}
 
+def get_shape(thisfeat):
+  thisid = thisfeat["id"]
+  if "coordinate_copy" in thisfeat["geometry"]:
+    copyname = thisfeat["geometry"]["coordinate_copy"]
+    if copyname in geoms:
+      return geoms[copyname]
+    else:
+      sys.stderr.write("can't handle out of order coordinate copies at this time.\n")
+      sys.stderr.write(thisid + " needs copy from " + copyname + "\n")
+      sys.exit(2)
+  else:
+    return shapely.geometry.asShape(thisfeat["geometry"])
+
 for feature in fullstruct["features"]:
-  geoms[feature["id"]] = shapely.geometry.asShape(feature["geometry"])
+  geoms[feature["id"]] = get_shape(feature)
   if not geoms[feature["id"]].is_valid:
     sys.stderr.write(feature["id"] + " is not valid\n")
 


### PR DESCRIPTION
fixes #236 

This adds a feature `coordinate_copy` to the database. Replacing `coordinates`, this entry requests to copy the existing coordinates from another feature, given as the argument. This can speed up development and shrink the native database. It is unclear at this time how important that is to performance, but it still can reduce cut/paste or copy errors. The `ohmec_data_na.js` database was scrubbed and reduced 17% in area by implementing 170 coordinate copies out of a total of 1330 (12%).

The documentation has been updated to define the feature, and utilities have been modified to use copies.