### PR TITLE
Add ability to do coordinate_copies from array of sources

### DIFF
--- a/ohmec.js
+++ b/ohmec.js
@@ -981,9 +981,34 @@ function geo_lint(dataset, convertFromNativeLands, replaceIndigenous, applyChero
           }
           if("coordinate_copy" in f.geometry) {
             if(f.geometry.coordinate_copy in fHash) {
-              f.geometry.coordinates = fHash[f.geometry.coordinate_copy].geometry.coordinates;
+              if(fHash[f.geometry.coordinate_copy].geometry.type === f.geometry.type) {
+                f.geometry.coordinates = fHash[f.geometry.coordinate_copy].geometry.coordinates;
+              } else {
+                throw "can't copy coordinates from " + f.geometry.coordinate_copy + " type " +
+                  fHash[f.geometry.coordinate_copy].geometry.type + " to " + f.id + " type " + f.geometry.type;
+              }
             } else {
               throw "can't copy coordinates from " + f.geometry.coordinate_copy + " for " + f.id;
+            }
+          }
+          if("coordinate_copies" in f.geometry) {
+            f.geometry.coordinates = [];
+            for(let copyid of f.geometry.coordinate_copies) {
+              if(copyid in fHash) {
+                if(f.geometry.type !== 'MultiPolygon') {
+                  throw "can't copy multiple coordinates to " + f.id + " type " + f.geometry.type;
+                } else if(fHash[copyid].geometry.type === 'Polygon') {
+                  f.geometry.coordinates.push(fHash[copyid].coordinates);
+                } else if(fHash[copyid].geometry.type === 'MultiPolygon') {
+                  for(let c=0;c<fHash[copyid].geometry.coordinates.length;c++) {
+                    f.geometry.coordinates.push(fHash[copyid].geometry.coordinates[c]);
+                  }
+                } else {
+                  throw "can't copy coordinates from " + copyid + " type " + fHash[copyid].geometry.type;
+                }
+              } else {
+                throw "can't copy coordinates from " + copyid + " for " + f.id;
+              }
             }
           }
         }

--- a/utilities/check_boundaries.py
+++ b/utilities/check_boundaries.py
@@ -169,6 +169,15 @@ def get_shape(thisfeat):
       sys.stderr.write("can't handle out of order coordinate copies at this time.\n")
       sys.stderr.write(thisid + " needs copy from " + copyname + "\n")
       sys.exit(2)
+  elif "coordinate_copies" in thisfeat["geometry"]:
+    thisfeat["coordinates"] = []
+    for copyname in thisfeat["geometry"]["coordinate_copies"]:
+      if geoms[copyname]["type"] == "Polygon":
+        thisfeat["coordinates"].append(geoms[copyname]["coordinates"])
+      if geoms[copyname]["type"] == "MultiPolygon":
+        for subarray in geoms[copyname]["coordinates"]:
+          thisfeat["coordinates"].append(subarray)
+    return shapely.geometry.asShape(thisfeat["geometry"])
   else:
     return shapely.geometry.asShape(thisfeat["geometry"])
 

--- a/utilities/geojson2kml.py
+++ b/utilities/geojson2kml.py
@@ -81,12 +81,21 @@ def get_coords(thisfeat):
   thisid = thisfeat["id"]
   if "coordinate_copy" in thisfeat["geometry"]:
     copyname = thisfeat["geometry"]["coordinate_copy"]
-    if copyname in coords:
+    if copyname in geoms:
       return coords[copyname]
     else:
       sys.stderr.write("can't handle out of order coordinate copies at this time.\n")
       sys.stderr.write(thisid + " needs copy from " + copyname + "\n")
       sys.exit(2)
+  elif "coordinate_copies" in thisfeat["geometry"]:
+    thisfeat["coordinates"] = []
+    for copyname in thisfeat["geometry"]["coordinate_copies"]:
+      if geoms[copyname]["type"] == "Polygon":
+        thisfeat["coordinates"].append(geoms[copyname]["coordinates"])
+      if geoms[copyname]["type"] == "MultiPolygon":
+        for subarray in geoms[copyname]["coordinates"]:
+          thisfeat["coordinates"].append(subarray)
+    return thisfeat["geometry"]["coordinates"]
   else:
     return thisfeat["geometry"]["coordinates"]
 

--- a/utilities/merge_geometry.py
+++ b/utilities/merge_geometry.py
@@ -51,6 +51,15 @@ def get_shape(thisfeat):
       sys.stderr.write("can't handle out of order coordinate copies at this time.\n")
       sys.stderr.write(thisid + " needs copy from " + copyname + "\n")
       sys.exit(2)
+  elif "coordinate_copies" in thisfeat["geometry"]:
+    thisfeat["coordinates"] = []
+    for copyname in thisfeat["geometry"]["coordinate_copies"]:
+      if geoms[copyname]["type"] == "Polygon":
+        thisfeat["coordinates"].append(geoms[copyname]["coordinates"])
+      if geoms[copyname]["type"] == "MultiPolygon":
+        for subarray in geoms[copyname]["coordinates"]:
+          thisfeat["coordinates"].append(subarray)
+    return shapely.geometry.asShape(thisfeat["geometry"])
   else:
     return shapely.geometry.asShape(thisfeat["geometry"])
 


### PR DESCRIPTION
Fixes #243

Adds ability to copy coordinates from multiple features into one new feature. Note this is not identical to a feature merge, which might combine two adjacent polygons into one, but rather an array of polygons into one `MultiPolygon`. For instance if one were to do a `coordinate_copies` array of `["TX","LA"]`, the border between Texas and Louisiana would still be visible.

A better example, and the inspiration for this feature, is the myriad combinations of islands in the Caribbean as they shift from one entity (eg. British Leeward Islands) to another (eg. West Indies Federation)