### PR TITLE
Add line spacing feature

### DIFF
--- a/ohmec.js
+++ b/ohmec.js
@@ -571,6 +571,9 @@ function getTextLabel(bounds, id, label, isPoint, properties, fontinfo, altPrope
     inner += '<text text-anchor="' + anchor + '"';
     inner += ' font-family="' + fontinfo.name + ', Courier, sans-serif"';
     inner += ' fill="' + fontinfo.color + '"';
+    if("labelSpacing" in properties) {
+      inner += ' letter-spacing="' + properties.labelSpacing + '"';
+    }
     inner += ' font-size="' + thisFontsize.toFixed(2) + 'px"';
     if("labelRotate" in properties || "labelX" in properties || "labelY" in properties) {
       inner += ' transform="';
@@ -998,7 +1001,7 @@ function geo_lint(dataset, convertFromNativeLands, replaceIndigenous, applyChero
                 if(f.geometry.type !== 'MultiPolygon') {
                   throw "can't copy multiple coordinates to " + f.id + " type " + f.geometry.type;
                 } else if(fHash[copyid].geometry.type === 'Polygon') {
-                  f.geometry.coordinates.push(fHash[copyid].coordinates);
+                  f.geometry.coordinates.push(fHash[copyid].geometry.coordinates);
                 } else if(fHash[copyid].geometry.type === 'MultiPolygon') {
                   for(let c=0;c<fHash[copyid].geometry.coordinates.length;c++) {
                     f.geometry.coordinates.push(fHash[copyid].geometry.coordinates[c]);


### PR DESCRIPTION
Fixes #245 

This adds the ability to do line spacing (aka "kerning") to spread (or crowd) letters in a label, useful for creating labels that span a wide length eg. Caribbean islands.

The feature is to add `labelSpacing` with a float value roughly from 0.0 (no effect) upwards. A value of 1.0 has twice the space as 0.0 (default), making the label width say 25-40% wider (depending upon the font). This is executed by simply passing the value on directly to the created SVG layer using SVG's `letter-spacing=` option.

The documentation has been updated.