### PR TITLE
Slightly over-OCD cleanup of the database

### DIFF
--- a/runlint
+++ b/runlint
@@ -1,4 +1,4 @@
 # Copyright OHMEC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-eslint ohmec_data_na.js time_slider.js ohmec.js | tee lint.out
+eslint ohmec.js time_slider.js ohmec_data_na.js ohmec_data_meso.js ohmec_data_ancient_americas.js ohmec_data_eur.js | tee lint.out


### PR DESCRIPTION
I noticed a few labeling errors in the database (`labalScale` instead of `labelScale`, `editdate` instead of `editdatestr`) and cleaned those up. While doing so I got a little OCD and put all of the properties in a fixed order for the features. Makes no material or performance difference. Also, added the other databases to the linting script