### PR TITLE
Add ability to enable/disable popups

### DIFF
--- a/ohmec.css
+++ b/ohmec.css
@@ -65,7 +65,7 @@ h1 {
   align: center;
   border: solid;
 }
-.curdate, .infobox {
+.curdate, .infobox, .popupselect {
   padding: 6px 8px;
   font: 14px/16px Helvetica, sans-serif;
   box-shadow: 0 0 15px rgba(0,0,0,0.2);


### PR DESCRIPTION
Fixes #222 

This adds a radio button on the panel that allows popups to be enabled or disabled. The popup is minimized unless hovered over, in which case it explains its purpose. Thereby it is of minimal intrusion. Disabling the popups can still be done via URL modification, and the URL modification text line is updated by clicking the radio button