### PR TITLE
Augment utility kml2geojson

### DIFF
--- a/utilities/kml2geojson.py
+++ b/utilities/kml2geojson.py
@@ -22,6 +22,10 @@ __license__    = "Apache License, Version 2.0"
 import sys
 import json
 import re
+from datetime import date
+
+today = date.today()
+edate = today.strftime("%Y:%0m:%0d")
 
 SIGDIGITS = 5
 
@@ -52,6 +56,13 @@ def parse_kml(filename):
           fm = re.search(r"<name>\[(.*)\]\s+(.*)\s+Polygon.*</name>", line)
           idname = fm.group(1)
           entity2name[idname] = fm.group(2)
+          ismulti = 1
+          if(idname not in multicoords):
+            multicoords[idname] = []
+        elif(re.search(r"<name>(.+?)\s+Polygon.*</name>", line)):
+          fm = re.search(r"<name>(.+?)\s+Polygon.*</name>", line)
+          idname = fm.group(1)
+          entity2name[idname] = ""
           ismulti = 1
           if(idname not in multicoords):
             multicoords[idname] = []
@@ -95,8 +106,8 @@ def export_coords(coords):
         "entity2type":"XXXX",
         "entity2name":"''' + ename + '''",
         "fidelity":"XXXX",
-        "editdate":"XXXX",
         "source":"XXXX",
+        "editdatestr":"''' + edate + '''",
         "startdatestr":"XXXX",
         "enddatestr":"XXXX"},
       "geometry":{
@@ -120,8 +131,8 @@ def export_multi_coords(coords):
         "entity2type":"XXXX",
         "entity2name":"''' + ename + '''",
         "fidelity":"XXXX",
-        "editdatestr":"XXXX",
         "source":"XXXX",
+        "editdatestr":"''' + edate + '''",
         "startdatestr":"XXXX",
         "enddatestr":"XXXX"},
       "geometry":{


### PR DESCRIPTION
Fixes #261 

Cc @kt1122

This change to `utilities/kml2geojson.py` makes the parsing of the KML sublayers more lenient, and inserts today's date for `startdatestr` (it was misspelled this whole time 😲 anyway). The new pattern matching algorithm for the sublayer (ie. shape within the layer) is as follows:

1. [`NAME1`] `NAME2` Polygon `n`
  a. creates a MultiPolygon with ID `NAME1` if it doesn't already exist
  b. appends the shape's coordinates to the MultiPolygon
  c. gives it the `entity2name` of `NAME2` (all these can of course be edited later)
2. `NAME` Polygon `n` (<<-- this feature is the newly added one)
  a. creates a MultiPolygon with ID `NAME` if it doesn't already exist
  b. appends the shape's coordinates to the MultiPolygon
  c. leaves `entity2name` unknown (`"XXXX"`)
3. `NAME`
  a. creates a Polygon with ID `NAME`
  b. adds the shape's coordinates