### PR TITLE
Fix one case of animating borderless highlighting

### DIFF
--- a/ohmec.js
+++ b/ohmec.js
@@ -402,7 +402,7 @@ function infoboxFeatureOn(e) {
   lastLayer = layer;
 
   // possibly update font color if it differs in style
-  if(layer.feature.style.borderless && layer.feature.style.hifontcolor !== layer.feature.style.fontcolor) {
+  if(layer.feature.style.borderless && layer.feature.style.hifontcolor !== layer.feature.style.fontcolor && !("animateTo" in layer.feature.properties)) {
     layer.feature.textOverlay.removeFrom(ohmap);
     layer.feature.textOverlay = updateTextOverlay(layer.feature, layer.getBounds(), true);
     layer.feature.textOverlay.addTo(ohmap);
@@ -438,7 +438,7 @@ function infoboxFeatureOff(e) {
 
   // possibly revert font color if it differs in style
   let layer = e.target;
-  if(layer.feature.style.borderless && layer.feature.style.hifontcolor !== layer.feature.style.fontcolor) {
+  if(layer.feature.style.borderless && layer.feature.style.hifontcolor !== layer.feature.style.fontcolor && !("animateTo" in layer.feature.properties)) {
     layer.feature.textOverlay.removeFrom(ohmap);
     layer.feature.textOverlay = updateTextOverlay(layer.feature, layer.getBounds(), false);
     layer.feature.textOverlay.addTo(ohmap);


### PR DESCRIPTION
Fixes #264

Noticed one case where one of the animating tribes (proto Maya in this case) had messed up font information when in highlight mode. The fix is to make sure that animating type features do not use the highlight font color, else it messes up the animation.