### PR TITLE
Allow user to more easily modify initial dates

### DIFF
--- a/about.html
+++ b/about.html
@@ -62,6 +62,13 @@
       lower ones to see their information.
     </p>
     <p>
+      The initial start date, current date, and end date can be
+      modified by typing in a new value into one of the three
+      boxes below the map. Hitting enter, tab, or otherwise
+      changing focus from the entry form will trigger a reload
+      of the current page with the date modified.
+    </p>
+    <p>
       Visualization and control can be modified by key press events.
       The following keys pressed <u>after click-selecting the map
       pane</u> have a particular effect.

--- a/index.html
+++ b/index.html
@@ -34,6 +34,20 @@
     &nbsp;<br/>
     <div id='map'></div>
     <p>
+      <table id='formtable'>
+        <tr>
+          <th>start date</td>
+          <th>current date</td>
+          <th>end date</td>
+        </tr>
+        <tr>
+          <td class="tdcenter"><input type="text" id="sdform" name="sdform" value="startdate"></td>
+          <td class="tdcenter"><input type="text" id="cdform" name="cdform" value="curdate"></td>
+          <td class="tdcenter"><input type="text" id="edform" name="edform" value="enddate"></td>
+        </tr>
+      </table>
+    </p>
+    <p>
       The <a href="http://ohmec.net">OHMEC</a> project is a free,
       open-source geography project, with a goal of representing all
       historical indigenous lands and political boundaries in a unified

--- a/index_aa.html
+++ b/index_aa.html
@@ -34,6 +34,20 @@
     &nbsp;<br/>
     <div id='map'></div>
     <p>
+      <table id='formtable'>
+        <tr>
+          <th>start date</td>
+          <th>current date</td>
+          <th>end date</td>
+        </tr>
+        <tr>
+          <td class='tdcenter'><input type="text" id="sdform" name="sdform" value="startdate"></td>
+          <td class='tdcenter'><input type="text" id="cdform" name="cdform" value="curdate"></td>
+          <td class='tdcenter'><input type="text" id="edform" name="edform" value="enddate"></td>
+        </tr>
+      </table>
+    </p>
+    <p>
       The <a href="http://ohmec.net">OHMEC</a> project is a free,
       open-source geography project, with a goal of representing all
       historical indigenous lands and political boundaries in a unified

--- a/index_cherokee.html
+++ b/index_cherokee.html
@@ -34,6 +34,20 @@
     &nbsp;<br/>
     <div id='map'></div>
     <p>
+      <table id='formtable'>
+        <tr>
+          <th>start date</td>
+          <th>current date</td>
+          <th>end date</td>
+        </tr>
+        <tr>
+          <td class="tdcenter"><input type="text" id="sdform" name="sdform" value="startdate"></td>
+          <td class="tdcenter"><input type="text" id="cdform" name="cdform" value="curdate"></td>
+          <td class="tdcenter"><input type="text" id="edform" name="edform" value="enddate"></td>
+        </tr>
+      </table>
+    </p>
+    <p>
       The <a href="http://ohmec.net">OHMEC</a> project is a free,
       open-source geography project, with a goal of representing all
       historical indigenous lands and political boundaries in a unified

--- a/index_ma.html
+++ b/index_ma.html
@@ -34,6 +34,20 @@
     &nbsp;<br/>
     <div id='map'></div>
     <p>
+      <table id='formtable'>
+        <tr>
+          <th>start date</td>
+          <th>current date</td>
+          <th>end date</td>
+        </tr>
+        <tr>
+          <td class="tdcenter"><input type="text" id="sdform" name="sdform" value="startdate"></td>
+          <td class="tdcenter"><input type="text" id="cdform" name="cdform" value="curdate"></td>
+          <td class="tdcenter"><input type="text" id="edform" name="edform" value="enddate"></td>
+        </tr>
+      </table>
+    </p>
+    <p>
       The <a href="http://ohmec.net">OHMEC</a> project is a free,
       open-source geography project, with a goal of representing all
       historical indigenous lands and political boundaries in a unified

--- a/index_meso.html
+++ b/index_meso.html
@@ -34,6 +34,20 @@
     &nbsp;<br/>
     <div id='map'></div>
     <p>
+      <table id='formtable'>
+        <tr>
+          <th>start date</td>
+          <th>current date</td>
+          <th>end date</td>
+        </tr>
+        <tr>
+          <td class="tdcenter"><input type="text" id="sdform" name="sdform" value="startdate"></td>
+          <td class="tdcenter"><input type="text" id="cdform" name="cdform" value="curdate"></td>
+          <td class="tdcenter"><input type="text" id="edform" name="edform" value="enddate"></td>
+        </tr>
+      </table>
+    </p>
+    <p>
       The <a href="http://ohmec.net">OHMEC</a> project is a free,
       open-source geography project, with a goal of representing all
       historical indigenous lands and political boundaries in a unified

--- a/index_nl.html
+++ b/index_nl.html
@@ -34,6 +34,20 @@
     &nbsp;<br/>
     <div id='map'></div>
     <p>
+      <table id='formtable'>
+        <tr>
+          <th>start date</td>
+          <th>current date</td>
+          <th>end date</td>
+        </tr>
+        <tr>
+          <td class="tdcenter"><input type="text" id="sdform" name="sdform" value="startdate"></td>
+          <td class="tdcenter"><input type="text" id="cdform" name="cdform" value="curdate"></td>
+          <td class="tdcenter"><input type="text" id="edform" name="edform" value="enddate"></td>
+        </tr>
+      </table>
+    </p>
+    <p>
       The <a href="http://ohmec.net">OHMEC</a> project is a free,
       open-source geography project, with a goal of representing all
       historical indigenous lands and political boundaries in a unified

--- a/index_viking.html
+++ b/index_viking.html
@@ -34,6 +34,20 @@
     &nbsp;<br/>
     <div id='map'></div>
     <p>
+      <table id='formtable'>
+        <tr>
+          <th>start date</td>
+          <th>current date</td>
+          <th>end date</td>
+        </tr>
+        <tr>
+          <td class="tdcenter"><input type="text" id="sdform" name="sdform" value="startdate"></td>
+          <td class="tdcenter"><input type="text" id="cdform" name="cdform" value="curdate"></td>
+          <td class="tdcenter"><input type="text" id="edform" name="edform" value="enddate"></td>
+        </tr>
+      </table>
+    </p>
+    <p>
       The <a href="http://ohmec.net">OHMEC</a> project is a free,
       open-source geography project, with a goal of representing all
       historical indigenous lands and political boundaries in a unified

--- a/ohmec.css
+++ b/ohmec.css
@@ -58,12 +58,39 @@ h1 {
 }
 #map {
   width: 95%;
-  height: 80%;
+  height: 75%;
   border-style: solid;
   border-color: #000040;
   margin-left: 2.5%;
   align: center;
   border: solid;
+}
+#mapalign {
+  width: 95%;
+  margin-left: 2.5%;
+}
+#formtable {
+  margin-left: auto;
+  margin-right: auto;
+  padding-top:    0px;
+  padding-bottom: 1px;
+  padding-left:   10px;
+  padding-right:  10px;
+  border-collapse: collapse;
+}
+#formtable th {
+  font-size: 15px;
+  font-family: "Benne", "Helvetica", serif;
+  text-align: center;
+}
+input[type='text'] {
+  width: 100px;
+  font-size: 15px;
+  font-family: "Consolas", "Courier", fixed;
+  text-align: center;
+}
+td.tdcenter {
+  text-align: center;
 }
 .curdate, .infobox, .popupselect {
   padding: 6px 8px;


### PR DESCRIPTION
Fixes #270

This check-in adds three text-input forms to each of the html pages. (Sidenote: it would be preferred to share this snippet and not have to cut/paste into each `.html` file; this is akin to `tablinks.js`, but that is not a very elegant solution either. Will leave as is for now.) These three forms allow the user to more obviously modify the default start date, current date, and/or end date rather than having to change the URL modifiers.

As currently coded, the modification of any of these forms immediately re-loads the current page with the modification implemented. This is as opposed to say attempting to live-update the timeline while keeping the current page still loaded. Since there is no history stored within a map interaction, this seems sufficient. Also, modification of the timeline is a little bit complicated, with error checking done, relocation of the timeline bubble for current data vis-a-vis start and end date, etc. I think it is a sufficient solution.

I'm happy to get a review by @kt1122 or @warrenjp but I think it is pretty simple so I'll likely check it in in a couple of days.