### PR TITLE
Fix bug with smart step in timeline slider

### DIFF
--- a/time_slider.js
+++ b/time_slider.js
@@ -30,6 +30,7 @@ L.Control.TimeLineSlider = L.Control.extend({
     let prefix = smartstep ? "" : "G";
     document.getElementById("stepFButton").value = prefix + "Step +";
     document.getElementById("stepRButton").value = prefix + "Step -";
+    this.options.smartStepFeature = smartstep;
   },
 
   onAdd: function() {
@@ -176,15 +177,19 @@ L.Control.TimeLineSlider = L.Control.extend({
         if (curTime > thisSlider.options.datesOfInterestSorted[i].getTime()) {
           let useStep = true;
           if(thisSlider.options.smartStepFeature) {
-            useStep = false;
-            for(let id of thisSlider.options.idAddsPerDOI[i+1]) {
-              if(boundsIntersect(thisSlider.options.mapBounds(), thisSlider.options.boundsHash[id])) {
-                useStep = true;
+            // if we're at the end of the map, then always go backwards,
+            // but there's nothing to iterate on here, so skip the check
+            if(thisSlider.options.idAddsPerDOI[i+1]) {
+              useStep = false;
+              for(let id of thisSlider.options.idAddsPerDOI[i+1]) {
+                if(boundsIntersect(thisSlider.options.mapBounds(), thisSlider.options.boundsHash[id])) {
+                  useStep = true;
+                }
               }
-            }
-            for(let id of thisSlider.options.idSubsPerDOI[i+1]) {
-              if(boundsIntersect(thisSlider.options.mapBounds(), thisSlider.options.boundsHash[id])) {
-                useStep = true;
+              for(let id of thisSlider.options.idSubsPerDOI[i+1]) {
+                if(boundsIntersect(thisSlider.options.mapBounds(), thisSlider.options.boundsHash[id])) {
+                  useStep = true;
+                }
               }
             }
           }


### PR DESCRIPTION
Fixes #279 

I found these two bugs while playing with PR #268. The smartstep toggle wasn't getting fixed in the timeline slider itself, only in the display of the button. And there are some cases (also seen in Ancient Americas) where - if the features end before `present` - you can't step backwards since the last entry of "Dates of Interest" is undefined. In that case, always move backwards, regardless of smart step.