### PR TITLE
Add ability to change popup styling, and create bridge popups

### DIFF
--- a/ohmec.css
+++ b/ohmec.css
@@ -132,11 +132,11 @@ td.tdcenter {
   background-color: rgba(4,112,255,0.7);
   color: #eee;
 }
-#popup {
+.popup_class {
   font: 16px New Tegomin, sans-serif;
   color: #eee;
 }
-#popup a {
+.popup_class a {
   color: #ffa0c0;
 }
 .curdate {

--- a/ohmec_data_meso.js
+++ b/ohmec_data_meso.js
@@ -74,8 +74,16 @@ dataMeso = {
         "coordinates":[-6.883, 37.216]},
     { "text":"<p>The <a href=\"https://en.wikipedia.org/wiki/Aztec_Empire\" target=\"_blank\">Spanish Conquest of the Aztecs</a> in August of 1521, greatly supported by embittered enemies of the Aztecs, ended the hegemony of the Empire and began the regional domination of the Spanish Nation. After the Aztecs fell, other tribes began one by one to fall to Spanish rule, though resistance remained until the 17th century.</p>",
       "startdatestr":"1521:08:13",
-      "enddatestr":"1649",
-      "coordinates":[-99.13333, 19.6]}
+      "enddatestr":"1599:12:30",
+      "coordinates":[-99.13333, 19.6]},
+    { "text":"<p>This Mesoamerica study covers the time period from 1800BC to 1600AD. To follow along with later North American history, click through to the <a href=\"index.html?curdatestr=1600:01:02&lon=-96.7&lat=20.2&z=5.5\">Modern North American Study</a> which covers the time period from 1600AD to present for all of North America.</p>",
+      "startdatestr":"1599:12:31",
+      "enddatestr":"1600",
+      "coordinates":[-100.0, 20.0],
+      "style":{
+        "fontcolor":   "#ffc0c0ff",
+        "hifontcolor": "#c0c0ffff",
+        "fillColor":   "#800000c0" }}
   ],
   "styles":[
     { "type": "default",

--- a/time_slider.js
+++ b/time_slider.js
@@ -60,7 +60,7 @@ L.Control.TimeLineSlider = L.Control.extend({
       '" max="' +
       this.options.timelineDateMax.getTime() +
       '" step="any" value="' +
-      this.options.timelineDateMin.getTime() +
+      this.options.timelineDateStart.getTime() +
       '"></input>';
     this.rangeObject = L.DomUtil.get(this.sliderDiv).children[0];
 


### PR DESCRIPTION
Fixes #296

This adds the ability to change (slightly) the style of markup in popups, including the background color, font name, font size, font color, and link font color. The documentation will be updated for this feature before it is committed.

Two popups have been added to "link" the Mesoamerican study with the (default) Modern North America study, exhibiting some of the popup style features (to use a red background).