### PR TITLE
Allow keypress of 1-9 to open up sources

### DIFF
--- a/about.html
+++ b/about.html
@@ -75,8 +75,12 @@
     </p>
     <table id="keytable">
       <tr>
-        <th>key</th>
+        <th width="50px">key</th>
         <th>effect</th>
+      </tr>
+      <tr>
+        <td>1-9</td>
+        <td>(If feature is highlighted) Open the source number indicated in the infobox.</td>
       </tr>
       <tr>
         <td>0</td>


### PR DESCRIPTION
Fixes #301 

This checks the keypress for a number 1-9, and if a feature is selected, and that feature has that number of sources or more, opens the feature source indicated by the press. Falls back on changing the background layer otherwise.

In addition, this adds a keyboard character a la 1️⃣ to guide the user to the notion of the keypress.

This updates the `about.html` page to indicate the interaction change, but still wish there was an easier way to convey this upon first viewing.