### PR TITLE
Add leadership (huetlatoni) of Aztec/Mexica/Tenochtitlan

### DIFF
--- a/ohmec.js
+++ b/ohmec.js
@@ -234,9 +234,6 @@ function urlString(mindate,maxdate,curdate) {
 
 let updateDirectLink = function() {
   let hrefText = location.href;
-  let splits = hrefText.split('?');
-  let latlon = ohmap.getCenter();
-  let conjoin = '?';
   let urlText = urlString(timelineDateMinOverride, timelineDateMaxOverride, curDate);
   linkSpan.textContent = urlText;
   linkSpan.href = urlText;
@@ -391,11 +388,25 @@ infobox.update = function(id, prop) {
     }
     if ("periodList" in fHash[id]) {
       for(let m in fHash[id].periodList) {
-        let startDate = str2date(fHash[id].periodList[m].startdatestr,false);
-        let endDate = str2date(fHash[id].periodList[m].enddatestr,true);
-        if(curDate >= startDate && curDate <= endDate) {
-          let pe = fHash[id].periodList[m].period;
-          thisHTML += '<div id="pinfo"><center>' + pe + '</center></div>';
+        let entry = fHash[id].periodList[m];
+        // error out if there are entries that don't conform to expectation
+        if("startdatestr" in entry && "enddatestr" in entry && "period" in entry) {
+          let startDate = str2date(entry.startdatestr,false);
+          let endDate = str2date(entry.enddatestr,true);
+          if(curDate >= startDate && curDate <= endDate) {
+            let pe = entry.period;
+            thisHTML += '<div id="pinfo"><center>' + pe + '</center></div>';
+          }
+        } else {
+          if(!("startdatestr" in entry)) {
+            throw "missing startdatestr in periodList for " + id;
+          }
+          if(!("enddatestr" in entry)) {
+            throw "missing enddatestr in periodList for " + id;
+          }
+          if(!("period" in entry)) {
+            throw "missing period in periodList for " + id;
+          }
         }
       }
     }
@@ -439,7 +450,7 @@ infobox.addTo(ohmap);
 let popupSelect = L.control();
 popupSelect.setPosition("topleft");
 
-popupSelect.update = function(id, prop) {
+popupSelect.update = function() {
   if(popupSelectExpanded) {
     if(popupFeatureEnabled) {
       this._div.innerHTML = '<input type="radio" id="psel" name="psel" checked /><label for="psel">popups enabled</label>';

--- a/ohmec_data_meso.js
+++ b/ohmec_data_meso.js
@@ -229,6 +229,26 @@ dataMeso = {
         { "startdatestr":"1000BC", "enddatestr":"351BC",  "period":"Middle Preclassic Period" },
         { "startdatestr":"350BC",  "enddatestr":"249",    "period":"Late Preclassic Period" }
       ]},
+    { "match":{ "entity1type": "civilization", "entity1name": "Aztec Alliance"},
+      "periods":[
+        { "startdatestr":"1367",    "enddatestr":"1387",   " period":"huetlatoani: Ācamāpichtli" },
+        { "startdatestr":"1391",    "enddatestr":"1415:06", "period":"huetlatoani: Huitzilihuitl" },
+        { "startdatestr":"1415:07", "enddatestr":"1426",    "period":"huetlatoani: Chīmalpopōca" },
+        { "startdatestr":"1427",    "enddatestr":"1440:06", "period":"huetlatoani: Itzcōhuātl" },
+        { "startdatestr":"1440:07", "enddatestr":"1468",    "period":"huetlatoani: Motēuczōma (I) Ilhuicamīna" },
+        { "startdatestr":"1469",    "enddatestr":"1481:06", "period":"huetlatoani: Axayacatl" },
+        { "startdatestr":"1481:07", "enddatestr":"1486:06", "period":"huetlatoani: Tizocic" },
+        { "startdatestr":"1486:07", "enddatestr":"1502:06", "period":"huetlatoani: Āhuizotl" },
+        { "startdatestr":"1502:07", "enddatestr":"1520:03", "period":"huetlatoani: Motēuczōma (II) Xocoyotzin" },
+        { "startdatestr":"1520:04", "enddatestr":"1520:12", "period":"huetlatoani: Cuitlāhuac" },
+        { "startdatestr":"1521",    "enddatestr":"1524",    "period":"huetlatoani: Cuāuhtemōc" }
+      ]},
+    { "match":{ "entity1type": "civilization", "entity1name": "Tenochtitlan"},
+      "periods":[
+        { "startdatestr":"1367",    "enddatestr":"1387",   " period":"huetlatoani: Ācamāpichtli" },
+        { "startdatestr":"1391",    "enddatestr":"1415:06", "period":"huetlatoani: Huitzilihuitl" },
+        { "startdatestr":"1415:07", "enddatestr":"1426",    "period":"huetlatoani: Chīmalpopōca" }
+      ]},
     { "match":{ "entity1type": "civilization", "entity1name": "Maya"},
       "periods":[
         { "startdatestr":"2000BC", "enddatestr":"1001BC", "period":"Early Preclassic Period" },


### PR DESCRIPTION
Fixes #308 

This adds the emperors ("huetlatoni") of the Aztec Alliance and Tenochtitlan (Mexica) tribes. For now it doesn't add the other members (Tlacopan, Texcoco) of the alliance, and marks the *huetlatoni* of the Aztec Alliance as that of Tenochtitlan.

In the process, found some nit bugs in the `periods` syntax checking and a few unused variables, that are cleaned up.